### PR TITLE
Add check if agahnim 2 has been defeated for ganon invincibility.

### DIFF
--- a/goalitem.asm
+++ b/goalitem.asm
@@ -50,10 +50,12 @@ CheckGanonVulnerability:
 		LDA $7EF374 : AND.b #$07 : CMP #$07 : BNE .fail ; require all pendants
 		LDA $7EF37A : AND.b #$7F : CMP #$7F : BNE .fail ; require all crystals
 		LDA $7EF3C5 : CMP.b #$03 : !BLT .fail ; require post-aga world state
+		LDA $7EF2DB : AND.b #$20 : BNE .fail ; require aga2 defeated (pyramid hole open)
 		BRA .success
 	+ ; CMP #$03 : BNE + this is a comment
 		;#$03 = Require All Crystals
 		LDA $7EF37A : AND.b #$7F : CMP #$7F : BNE .fail ; require all crystals
+		LDA $7EF2DB : AND.b #$20 : BNE .fail ; require aga2 defeated (pyramid hole open)
 		BRA .success
 	+
 .fail : CLC : RTL


### PR DESCRIPTION
Overlay state flag of pyramid hole screen gets updated after Aga 2 cutscene. This seems to be the easiest SRAM value to use for verifying that Aga2 is defeated.