### PR TITLE
Add MenuSpeed option

### DIFF
--- a/pendantcrystalhud.asm
+++ b/pendantcrystalhud.asm
@@ -134,18 +134,20 @@ RTL
 ;RTL
 ;================================================================================
 BringMenuDownEnhanced:
-	LDA.l QuickMenu : AND.l TournamentSeedInverse : BEQ +
-		REP #$20 ; set 16-bit accumulator
-			LDA.w #$FF18 : STA $EA ; immediately scroll to the end
-		SEP #$20 ; set 8-bit accumulator
-		INC $0200
-		RTL
-	+
 	REP #$20 ; set 16-bit accumulator
-		LDA $EA : !SUB.l MenuSpeed : STA $EA : CMP.w #$FF18
-		!BGE .noOvershoot
-			LDA.w #$FF18 : STA $EA : CMP.w #$FF18
+		LDA.l TournamentSeed : AND.w #$00FF
+		BEQ +
+			LDA.w #$0008 : BRA ++ ; use default speed on tournament seeds
+		+
+			LDA.l MenuSpeed
+		++
+
+		EOR.w #$FFFF : !ADD.w #$0001 ; negate menu speed
+
+		!ADD.w $EA : CMP.w #$FF18 : !BGE .noOvershoot
+			LDA.w #$FF18 ; if we went past the limit, go to the limit
 		.noOvershoot
+		STA $EA : CMP.w #$FF18
 	SEP #$20 ; set 8-bit accumulator
 	BNE .notDoneScrolling
 		INC $0200
@@ -153,13 +155,17 @@ BringMenuDownEnhanced:
 RTL
 ;================================================================================
 RaiseHudMenu:
-	LDA.l QuickMenu : AND.l TournamentSeedInverse : AND.w #$00FF : BEQ +
-		LDA.w #$0000 : STA $EA : RTL
+	LDA.l TournamentSeed : AND.w #$00FF
+	BEQ +
+		LDA.w #$0008 : BRA ++ ; use default speed on tournament seeds
 	+
-	LDA $EA : !ADD.l MenuSpeed : STA $EA
-	!BLT .noOvershoot
-		LDA.w #$0000 : STA $EA
+		LDA.l MenuSpeed : AND.w #$00FF
+	++
+
+	!ADD.w $EA : BMI .noOvershoot
+		LDA.w #$0000 ; if we went past the limit, go to the limit
 	.noOvershoot
+	STA $EA
 RTL
 ;================================================================================
 ShowDungeonItems:

--- a/pendantcrystalhud.asm
+++ b/pendantcrystalhud.asm
@@ -142,7 +142,10 @@ BringMenuDownEnhanced:
 		RTL
 	+
 	REP #$20 ; set 16-bit accumulator
-		LDA $EA : !SUB.w #$0008 : STA $EA : CMP.w #$FF18
+		LDA $EA : !SUB.l MenuSpeed : STA $EA : CMP.w #$FF18
+		!BGE .noOvershoot
+			LDA.w #$FF18 : STA $EA : CMP.w #$FF18
+		.noOvershoot
 	SEP #$20 ; set 8-bit accumulator
 	BNE .notDoneScrolling
 		INC $0200
@@ -153,7 +156,10 @@ RaiseHudMenu:
 	LDA.l QuickMenu : AND.l TournamentSeedInverse : AND.w #$00FF : BEQ +
 		LDA.w #$0000 : STA $EA : RTL
 	+
-	LDA $EA : !ADD.w #$0008 : STA $EA
+	LDA $EA : !ADD.l MenuSpeed : STA $EA
+	!BLT .noOvershoot
+		LDA.w #$0000 : STA $EA
+	.noOvershoot
 RTL
 ;================================================================================
 ShowDungeonItems:

--- a/tables.asm
+++ b/tables.asm
@@ -227,6 +227,10 @@ db #$04 ; #$04 - 4 Bottles (default)
 BottleLimitReplacement:
 db #$47 ; #$47 - 20 Rupees (default)
 ;--------------------------------------------------------------------------------
+org $3080b0 ; PC 0x1800b0
+MenuSpeed:
+dw #$0008 ; #$0008 (default)
+;--------------------------------------------------------------------------------
 org $308100 ; PC 0x180100 (0x40 bytes)
 ShovelSpawnTable:
 	db $B2 ; Gold Bee

--- a/tables.asm
+++ b/tables.asm
@@ -180,8 +180,8 @@ LinkStartingRupees:
 dw #$0000
 ;--------------------------------------------------------------------------------
 org $308048 ; PC 0x180048
-QuickMenu:
-db #$00 ; #$00 = Off (default) - #$01 = On
+MenuSpeed:
+db #$08 ; #$08 (default) - higher is faster - #$E8 = instant open
 org $0DDD9A ; PC 0x6DD9A (equipment.asm:95) ; Menu Down Chime
 db #$11 ; #$11 = Vwoop Down (Default) - #$20 = Menu Chime
 org $0DDF2A ; PC 0x6DF2A (equipment.asm:466) ; Menu Up Chime
@@ -226,10 +226,6 @@ BottleLimit:
 db #$04 ; #$04 - 4 Bottles (default)
 BottleLimitReplacement:
 db #$47 ; #$47 - 20 Rupees (default)
-;--------------------------------------------------------------------------------
-org $3080b0 ; PC 0x1800b0
-MenuSpeed:
-dw #$0008 ; #$0008 (default)
 ;--------------------------------------------------------------------------------
 org $308100 ; PC 0x180100 (0x40 bytes)
 ShovelSpawnTable:


### PR DESCRIPTION
This adds a setting that allows changing the speed of the menu opening/closing animation. I created it as an alternative to the QuickMenu option. Some players have found the instant menu jarring, or even painful because of the sudden changes in brighness upon opening/closing the menu.

I was not able to place the setting next to to the other menu settings because of lack of space, but put it in the next chunk of open space I could find.