### PR TITLE
Create a flag to toggle off Fake Worlds

### DIFF
--- a/darkworldspawn.asm
+++ b/darkworldspawn.asm
@@ -61,6 +61,12 @@ SetDeathWorldChecked:
 	PLA
 RTL
 ;--------------------------------------------------------------------------------
+FakeWorldFix:
+	LDA FixFakeWorld : BEQ +
+		LDA $8A : AND.b #$40 : STA $7EF3CA
+	+
+RTL
+;--------------------------------------------------------------------------------
 MasterSwordFollowerClear:
 	LDA $7EF3CC
 	CMP #$0E : BEQ .clear ; clear master sword follower

--- a/inventory.asm
+++ b/inventory.asm
@@ -830,6 +830,7 @@ RTL
 ;--------------------------------------------------------------------------------
 ClearOWKeys:
 	PHA
+	JSL.l FakeWorldFix
 	LDA.l GenericKeys : BEQ +
 		PLA : LDA $7EF38B : STA $7EF36F
 		RTL

--- a/tables.asm
+++ b/tables.asm
@@ -728,6 +728,13 @@ org $308173 ; PC 0x180173
 Bob:
 db #$01 ; #00 = Off - #$01 = On (Default)
 ;================================================================================
+org $308174 ; PC 0x180174
+; Flag to fix Fake Light World/Fake Dark World as caused by leaving the underworld
+; to the other world (As can be caused by EG, Certain underworld clips, or Entance Randomizer).
+; Currently, Fake Worlds triggered by other causes like YBA's Fake Flute, are not affected.
+FixFakeWorld:
+db #$00 ; #00 = Fix Off (Default) - #$01 = Fix On
+;================================================================================
 org $308190 ; PC 0x180190
 TimerStyle:
 db #$00 ; #$00 = Off (Default) - #$01 Countdown - #$02 = Stopwatch


### PR DESCRIPTION
Add a new rom flag to disable fake Light/Dark worlds from occurring as a result of underworld travel. (Other methods of fake worlds like YBA Fake Flute are not changed).

Entrance Randomizer intends to use this flag to fix the Fake Light world from traveling though sewers when Hyrule Castle is in the dark world, as well as to implement new shuffle modes that involve deliberate cross-world caves without needing to grant pearl and mirror like the current insanity mode does.

This will allow us to fix sporchia/alttp_vt_randomizer#270

Note that placing the call to `FakeWorldFix` in `ClearOWKeys` is just to avoid having to add another hook. The call can be placed in any early hook of `PreOverworld_LoadProperties`. Another reasonable place to put it is in my music hook from pull request #18. 