### PR TITLE
Fix graphics when throwing items to fairy

### DIFF
--- a/hooks.asm
+++ b/hooks.asm
@@ -523,8 +523,8 @@ LDA.w BottleListExpanded, X
 org $09895C ; 4895C - ancilla_init.asm:1344 (LDA PotionList, X)
 LDA.w PotionListExpanded, X
 ;--------------------------------------------------------------------------------
-org $098A36 ; <- 48A36 - ancilla_init.asm:1432 (LDA AddReceiveItem.item_graphics_indices, Y : STA $72)
-LDA AddReceivedItemExpanded_item_graphics_indices, Y
+;org $098A36 ; <- 48A36 - ancilla_init.asm:1432 (LDA AddReceiveItem.item_graphics_indices, Y : STA $72)
+;LDA AddReceivedItemExpanded_item_graphics_indices, Y
 ;--------------------------------------------------------------------------------
 org $06D1EB ; 351EB - sprite_absorbable.asm:364 (STA $7EF375) ; bugbug commented out until i figure out why it doesn't work
 JSL HandleBombAbsorbtion


### PR DESCRIPTION
This hook will not work without another one that changes the data bank. Which apparently was never checked in due to green mail approach to fixing the freeze did not work out.

I've not had the opportunity to test this to prove that it works, but it is the only relevant change in v29 that could be causing the graphical issue, and does appear to be using the wrong bank as stated above.