### PR TITLE
Pyramid spawn updates

### DIFF
--- a/darkworldspawn.asm
+++ b/darkworldspawn.asm
@@ -17,7 +17,6 @@ RTL
 ;--------------------------------------------------------------------------------
 DarkWorldFlagSet:
 	PHA
-	LDA !FORCE_PYRAMID : AND.b #$08 : BNE .pyramid
 	
 	LDA Bugfix_PreAgaDWDungeonDeathToFakeDW : BEQ +
 		LDA $10 : CMP #$12 : BEQ .done ; don't do anything in death mode
@@ -37,27 +36,27 @@ DarkWorldFlagSet:
 	.done
 	PLA
 RTL
-	.pyramid
-	LDA !FORCE_PYRAMID : AND.b #$F7 : STA !FORCE_PYRAMID ; clear pyramid flag
-	LDA #$40 : STA $7EF3CA ; set flag to dark world
-	LDA $7EF3CC : CMP #$08 : BNE + : LDA.b #$07 : STA $7EF3CC : + ; convert dwarf to frog
-	PLA
-RTL
+
 ;--------------------------------------------------------------------------------
 SetDeathWorldChecked:
 	PHA
 	LDA $1B : BEQ + ; skip this for indoors
 		LDA $040C : CMP #$FF : BNE .done ; unless it's a cave
+
+		LDA $A0 : BNE + : LDA GanonPyramidRespawn : BEQ + ; check if we died in ganon's room and pyramid respawn is enabled
+			BRA .pyramid
 	+
+	
 	LDA $7EF3C5 : CMP.b #$03 : !BGE .done; thing we originally did - skip if agahnim 1 is dead
 	
-	LDA $1B : BEQ + : LDA $A0 : BNE + : LDA GanonPyramidRespawn : BEQ + ; check if we died in ganon's room and pyramid respawn is enabled
-		LDA !FORCE_PYRAMID : ORA.b #$08 : STA !FORCE_PYRAMID ; set pyramid flag
-		BRL DarkWorldFlagSet_pyramid
-	+
 	LDA.b #$00 : STA $7EF3CA : STA $7E0FFF ; set the world to the light world if he's still alive
 	LDA $7EF3CC : CMP #$07 : BNE .done : LDA.b #$08 : STA $7EF3CC ; convert frog to dwarf
 	.done
+	PLA
+RTL
+	.pyramid
+	LDA #$40 : STA $7EF3CA ; set flag to dark world
+	LDA $7EF3CC : CMP #$08 : BNE + : LDA.b #$07 : STA $7EF3CC : + ; convert dwarf to frog
 	PLA
 RTL
 ;--------------------------------------------------------------------------------


### PR DESCRIPTION
Move the pyramid spawn forcing code to run before the Aga1 check. The whole point of the code is to force a pyramid spawn even if you are fighting Ganon in the fake world. (Otherwise a branch to `.done` would have been good enough). It only makes sense to also do the same thing if Aga1 is dead.

The `FORCE_PYRAMID` SRAM flag was only ever set in `SetDeathWorldChecked`, which then branches immediately to the code that clears it so I removed that flag entirely.

Move the spawn on pyramid code from DarkWorldFlagSet to SetDeathWorldChecked, because it never actually ran in the first function, due to the previous observation.