### PR TITLE
Retro Mode Arrow Fix

### DIFF
--- a/events.asm
+++ b/events.asm
@@ -127,7 +127,7 @@ OnNewFile:
 		
 		LDA ArrowMode : BEQ .continue ; Customizer Rupee Bow Fix
 		LDA $7EF38E : BEQ .continue ; Anything but zero is good
-			LDA #$01, X : STA $7EF377, X
+			LDA #$01, X : STA $7EF377, X ; Set Arrows to 1
                 .continue
 		
 		SEP #$20 ; set 8-bit accumulator

--- a/events.asm
+++ b/events.asm
@@ -124,7 +124,12 @@ OnNewFile:
 			LDA StartingEquipment, X : STA $7EF340, X
 			INX : INX
 		CPX.w #$004F : !BLT -
-
+		
+		LDA ArrowMode : BEQ .continue ; Customizer Rupee Bow Fix
+		LDA $7EF38E : BEQ .continue ; Anything but zero is good
+			LDA #$01, X : STA $7EF377, X
+                .continue
+		
 		SEP #$20 ; set 8-bit accumulator
 		;LDA #$FF : STA !RNG_ITEM_LOCK_IN ; reset rng item lock-in
 		LDA.l PreopenCurtains : BEQ +

--- a/events.asm
+++ b/events.asm
@@ -128,7 +128,7 @@ OnNewFile:
 		LDA ArrowMode : BEQ .continue ; Customizer Rupee Bow Fix
 		LDA $7EF38E : BEQ .continue ; Anything but zero is good
 			LDA #$01, X : STA $7EF377, X ; Set Arrows to 1
-                .continue
+		.continue
 		
 		SEP #$20 ; set 8-bit accumulator
 		;LDA #$FF : STA !RNG_ITEM_LOCK_IN ; reset rng item lock-in

--- a/retro.asm
+++ b/retro.asm
@@ -38,6 +38,9 @@ DecrementArrows:
 		DEC : STA $7EF377 : INC
 		BRA .done
 	.rupees
+		LDA $7EF340 : CMP.b #$01 : BNE .has_arrow
+			LDA.b #$00 : RTL
+		.has_arrow: 
 		LDA $7EF340 : AND.b #$01 : BEQ +
 			LDA.b $0B99 : BNE + ; Arrow Game active and has credits left
 			LDA.b $0B9A : BNE + ; Arrow Game active and on last arrow


### PR DESCRIPTION
Added a branch to disallow the firing of an arrow without obtaining arrows in Retro Mode
When starting with Silver Arrows in Customizer, interesting glitches occur. This fixes those glitches.