### PR TITLE
Compiler/assembler fixes for Asar

### DIFF
--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -141,9 +141,7 @@ org $A186B0 ; static mapping area, do not move
 incsrc hud.asm
 warnpc $A18800
 
-org $A18800 ; static mapping area
 incsrc zsnes.asm
-warnpc $A19000
 
 org $A1A000 ; static mapping area. Referenced by front end. Do not move.
 incsrc invertedstatic.asm
@@ -584,7 +582,7 @@ Messaging_Text:
 org $0FFD94
 Overworld_TileAttr:
 
-org $1BC97C:
+org $1BC97C
 Overworld_DrawPersistentMap16:
 
 org $1BED03

--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -141,7 +141,9 @@ org $A186B0 ; static mapping area, do not move
 incsrc hud.asm
 warnpc $A18800
 
+org $A18800 ; static mapping area
 incsrc zsnes.asm
+warnpc $A19000
 
 org $A1A000 ; static mapping area. Referenced by front end. Do not move.
 incsrc invertedstatic.asm

--- a/dialog.asm
+++ b/dialog.asm
@@ -262,7 +262,13 @@ DialogItemReceive:
 		LDA.w #$FFFF
 		BRA .done
 	+
+	; need to indicate to Asar that we know Ancilla_ReceiveItem_item_messages
+	; is in the $08 databank, so that it uses the lower 16 bits of the label
+	; for LDA {abs},Y
+	bank $08
 	LDA Ancilla_ReceiveItem_item_messages, Y
+	bank auto
+
 	.done
 	CMP.w #$FFFF
 RTL

--- a/dialog.asm
+++ b/dialog.asm
@@ -262,13 +262,7 @@ DialogItemReceive:
 		LDA.w #$FFFF
 		BRA .done
 	+
-	; need to indicate to Asar that we know Ancilla_ReceiveItem_item_messages
-	; is in the $08 databank, so that it uses the lower 16 bits of the label
-	; for LDA {abs},Y
-	bank $08
-	LDA Ancilla_ReceiveItem_item_messages, Y
-	bank auto
-
+	LDA.w Ancilla_ReceiveItem_item_messages, Y
 	.done
 	CMP.w #$FFFF
 RTL

--- a/flute.asm
+++ b/flute.asm
@@ -22,7 +22,7 @@ SpawnHauntedGroveItem:
 	LDA.b #$FF : STA $0B58, Y
 	LDA.b #$30 : STA $0F10, Y
 
-	LDA $22 : !ADD .x_offsets, X
+	LDA $22 : !ADD.l .x_offsets, X
 							AND.b #$F0 : STA $0D10, Y
 	LDA $23 : ADC.b #$00			   : STA $0D30, Y
 

--- a/inventory.asm
+++ b/inventory.asm
@@ -1134,15 +1134,15 @@ SpawnShovelItem:
 		LDX.b #$00
 		LDA $2F : CMP.b #$04 : BEQ + : INX : +
 
-		LDA .x_speeds, X : STA $0D50, Y
+		LDA.l .x_speeds, X : STA $0D50, Y
 
 		LDA.b #$00 : STA $0D40, Y
 		LDA.b #$18 : STA $0F80, Y
 		LDA.b #$FF : STA $0B58, Y
 		LDA.b #$30 : STA $0F10, Y
 
-		LDA $22 : !ADD .x_offsets, X
-		                        AND.b #$F0 : STA $0D10, Y
+		LDA $22 : !ADD.l .x_offsets, X
+				                AND.b #$F0 : STA $0D10, Y
 		LDA $23 : ADC.b #$00               : STA $0D30, Y
 
 		LDA $20 : !ADD.b #$16 : AND.b #$F0 : STA $0D00, Y

--- a/inverted.asm
+++ b/inverted.asm
@@ -206,16 +206,16 @@ MirrorBonk:
 		REP #$30
 		LDX #$0000
 		.loop
-			LDA .bonkRectanglesTable, X ;Load X1
+			LDA.l .bonkRectanglesTable, X ;Load X1
 			CMP $22 : !BGE ++
 			;IF X > X1
-			LDA .bonkRectanglesTable+2, X ; Load X2
+			LDA.l .bonkRectanglesTable+2, X ; Load X2
 			CMP $22 : !BLT ++ 
 			;IF X < X2
-			LDA .bonkRectanglesTable+4, X ;Load Y1
+			LDA.l .bonkRectanglesTable+4, X ;Load Y1
 			CMP $20 : !BGE ++
 			;IF Y > Y1
-			LDA .bonkRectanglesTable+6, X ; Load Y2
+			LDA.l .bonkRectanglesTable+6, X ; Load Y2
 			CMP $20 : !BLT ++ 
 			;IF Y < Y2
 			;Bonk Here

--- a/password.asm
+++ b/password.asm
@@ -90,7 +90,7 @@ Password_Main:
 	+
 	LDA $F4 : ORA $F6 : AND.b #$C0 : BEQ + ; face button
 		LDX !PASSWORD_SELECTION_POSITION
-		LDA .selectionValues, X : BPL ++
+		LDA.l .selectionValues, X : BPL ++
 			CMP #$F0 :  BNE +++
 				INC $11
 				BRA .endOfButtonChecks
@@ -285,23 +285,23 @@ PasswordEraseOldCursors:
 
 	;Code Cursor
 	LDA !PASSWORD_CODE_POSITION : AND.w #$00FF : ASL : TAX
-	LDA .code_offsets, X
+	LDA.l .code_offsets, X
 	!ADD.w #$20*!PASSWORD_DISPLAY_START_Y+!PASSWORD_DISPLAY_START_X+$6000
 	XBA ; because big endian is needed
-	STA $1002+Password_StripeImageTemplate_CodeCursorErase-Password_StripeImageTemplate
+	STA.l $1002+Password_StripeImageTemplate_CodeCursorErase-Password_StripeImageTemplate
 
 	;selection cursor
 	LDA !PASSWORD_SELECTION_POSITION : AND.w #$00FF : ASL : TAX
-	LDA .selection_offsets, X
+	LDA.l .selection_offsets, X
 	!ADD.w #$20*!PASSWORD_INPUT_START_Y+!PASSWORD_INPUT_START_X+$6000
 	XBA ; because big endian is needed
-	STA $1002+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
+	STA.l $1002+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
 	XBA : !ADD.w #$0020 : XBA
-	STA $1002+$0C+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
+	STA.l $1002+$0C+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
 	XBA : !ADD.w #$0003 : XBA
-	STA $1002+$14+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
+	STA.l $1002+$14+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
 	XBA : !ADD.w #$0040-$0003 : XBA
-	STA $1002+$1C+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
+	STA.l $1002+$1C+Password_StripeImageTemplate_SelectionCursorErase-Password_StripeImageTemplate
 
 	SEP #$20 ; restore 8-bit accumulator
 RTS
@@ -318,23 +318,23 @@ PasswordSetNewCursors:
 	REP #$20 ; set 16-bit accumulator
 	;Code Cursor
 	LDA !PASSWORD_CODE_POSITION : AND.w #$00FF : ASL : TAX
-	LDA PasswordEraseOldCursors_code_offsets, X
+	LDA.l PasswordEraseOldCursors_code_offsets, X
 	!ADD.w #$20*!PASSWORD_DISPLAY_START_Y+!PASSWORD_DISPLAY_START_X+$6000
 	XBA ; because big endian is needed
-	STA $1002+Password_StripeImageTemplate_CodeCursorDraw-Password_StripeImageTemplate
+	STA.l $1002+Password_StripeImageTemplate_CodeCursorDraw-Password_StripeImageTemplate
 
 	;Selection cursor
 	LDA !PASSWORD_SELECTION_POSITION : AND.w #$00FF : ASL : TAX
-	LDA PasswordEraseOldCursors_selection_offsets, X
+	LDA.l PasswordEraseOldCursors_selection_offsets, X
 	!ADD.w #$20*!PASSWORD_INPUT_START_Y+!PASSWORD_INPUT_START_X+$6000
 	XBA ; because big endian is needed
-	STA $1002+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
+	STA.l $1002+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
 	XBA : !ADD.w #$0020 : XBA
-	STA $1002+$0C+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
+	STA.l $1002+$0C+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
 	XBA : !ADD.w #$0003 : XBA
-	STA $1002+$14+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
+	STA.l $1002+$14+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
 	XBA : !ADD.w #$0040-$0003 : XBA
-	STA $1002+$1C+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
+	STA.l $1002+$1C+Password_StripeImageTemplate_SelectionCursorDraw-Password_StripeImageTemplate
 
 	SEP #$20 ; restore 8-bit accumulator
 RTS

--- a/pendantcrystalhud.asm
+++ b/pendantcrystalhud.asm
@@ -472,15 +472,15 @@ DrawPendantCrystalDiagram:
 		REP #$30 ; Set 16-bit accumulator & index registers
 		LDX.w #$0000 ; Paint entire box black & draw empty pendants and crystals
 		-
-	        LDA .row0, X : STA $12EA, X
-	        LDA .row1, X : STA $132A, X
-	        LDA .row2, X : STA $136A, X
-	        LDA .row3, X : STA $13AA, X
-	        LDA .row4, X : STA $13EA, X
-	        LDA .row5, X : STA $142A, X
-	        LDA .row6, X : STA $146A, X
-	        LDA .row7, X : STA $14AA, X
-	        LDA .row8, X : STA $14EA, X
+	        LDA.l .row0, X : STA $12EA, X
+	        LDA.l .row1, X : STA $132A, X
+	        LDA.l .row2, X : STA $136A, X
+	        LDA.l .row3, X : STA $13AA, X
+	        LDA.l .row4, X : STA $13EA, X
+	        LDA.l .row5, X : STA $142A, X
+	        LDA.l .row6, X : STA $146A, X
+	        LDA.l .row7, X : STA $14AA, X
+	        LDA.l .row8, X : STA $14EA, X
 		INX #2 : CPX.w #$0014 : BCC -
 		
 		;pendants

--- a/rngfixes.asm
+++ b/rngfixes.asm
@@ -114,10 +114,10 @@ InitRNGPointerTable:
 	REP #$30 ; set 16-bit accumulator & index registers
 	LDX.w #$0000
 	-
-		LDA .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
-		LDA .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
-		LDA .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
-		LDA .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
+		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
+		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
+		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
+		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
 	CPX.w #$007F : !BLT -
 	PLP : PLX
 RTL

--- a/roomloading.asm
+++ b/roomloading.asm
@@ -5,7 +5,7 @@ LoadRoomHook:
     JSL Dungeon_LoadRoom
     REP #$10 ; 16 bit XY
         LDX $A0 ; Room ID
-        LDA RoomCallbackTable, X
+        LDA.l RoomCallbackTable, X
     SEP #$10 ; 8 bit XY
     JSL UseImplicitRegIndexedLongJumpTable
 ; Callback routines:

--- a/shopkeeper.asm
+++ b/shopkeeper.asm
@@ -222,13 +222,13 @@ SpritePrep_ShopKeeper:
 
     ; If the item is $FF, make it not show (as if already taken)
 	LDA !SHOP_INVENTORY : CMP.b #$FF : BNE +
-		LDA !SHOP_STATE : ORA Shopkeeper_ItemMasks : STA !SHOP_STATE
+		LDA !SHOP_STATE : ORA.l Shopkeeper_ItemMasks : STA !SHOP_STATE
 	+
 	LDA !SHOP_INVENTORY+4 : CMP.b #$FF : BNE +
-		LDA !SHOP_STATE : ORA Shopkeeper_ItemMasks+1 : STA !SHOP_STATE
+		LDA !SHOP_STATE : ORA.l Shopkeeper_ItemMasks+1 : STA !SHOP_STATE
 	+
 	LDA !SHOP_INVENTORY+8 : CMP.b #$FF : BNE +
-		LDA !SHOP_STATE : ORA Shopkeeper_ItemMasks+2 : STA !SHOP_STATE
+		LDA !SHOP_STATE : ORA.l Shopkeeper_ItemMasks+2 : STA !SHOP_STATE
 	+
 
 	PLP : PLY : PLX

--- a/stats/main.asm
+++ b/stats/main.asm
@@ -289,7 +289,7 @@ RenderCreditsStatCounter:
 	LSR #3
 	AND.w #$001E
     TAX
-    LDA BitMasks,x
+    LDA.l BitMasks,x
     AND !ValueLow
     STA !ValueLow
     
@@ -299,7 +299,7 @@ RenderCreditsStatCounter:
     AND.w #$0007        ;   CCC
     BEQ +
     ASL : TAX
-    LDA ValueCaps,x
+    LDA.l ValueCaps,x
     CMP !ValueLow
     !BGE +
     STA !ValueLow

--- a/tablets.asm
+++ b/tablets.asm
@@ -95,7 +95,7 @@ IsMedallion:
 RTL
 ;--------------------------------------------------------------------------------
 LoadNarrowObject:
-	LDA AddReceivedItemExpanded_wide_item_flag, X : STA ($92), Y ; AddReceiveItem.wide_item_flag?
+	LDA.l AddReceivedItemExpanded_wide_item_flag, X : STA ($92), Y ; AddReceiveItem.wide_item_flag?
 RTL
 ;--------------------------------------------------------------------------------
 DrawNarrowDroppedObject:
@@ -114,8 +114,8 @@ DrawNarrowDroppedObject:
     
     ; always use the same character graphic (0x34)
     LDA.b #$34 : STA ($90), Y : INY
-    
-    LDA AddReceivedItemExpanded_properties, X : BPL .valid_lower_properties
+
+    LDA.l AddReceivedItemExpanded_properties, X : BPL .valid_lower_properties
     
     LDA $74
 

--- a/utilities.asm
+++ b/utilities.asm
@@ -27,7 +27,7 @@ GetSpriteID:
 	PHX
 	PHB : PHK : PLB
 	;--------
-	TAX : LDA .gfxSlots, X ; look up item gfx
+	TAX : LDA.l .gfxSlots, X ; look up item gfx
 	PLB : PLX
 	CMP.b #$F9 : !BGE .specialHandling
 RTL
@@ -159,7 +159,7 @@ GetSpritePalette:
 	PHX
 	PHB : PHK : PLB
 	;--------
-	TAX : LDA .gfxPalettes, X ; look up item gfx
+	TAX : LDA.l .gfxPalettes, X ; look up item gfx
 	PLB : PLX
 	CMP.b #$FA : !BGE .specialHandling
 RTL
@@ -314,7 +314,7 @@ IsNarrowSprite:
 	;----
 	-
 	CPX.b #$24 : !BGE .false ; finish if we've done the whole list
-	CMP .smallSprites, X : BNE + ; skip to next if we don't match
+	CMP.l .smallSprites, X : BNE + ; skip to next if we don't match
 	;--
 	SEC ; set true state
 	BRA .done ; we're done
@@ -608,7 +608,7 @@ CountBits:
 	AND #$07                ; Put out <2:0> in X
 	TAX                     ; And save in X
 	LDA NybbleBitCounts, Y  ; Fetch count for Y
-	ADC NybbleBitCounts, X  ; Add count for X & C
+	ADC.l NybbleBitCounts, X  ; Add count for X & C
 	PLB
 RTL
 

--- a/zsnes.asm
+++ b/zsnes.asm
@@ -1,6 +1,4 @@
 ;--------------------------------------------------------------------------------
-org $A18800 ; static mapping area
-
 CheckZSNES:
     SEP #$28
     LDA #$FF
@@ -97,16 +95,17 @@ JML.l ReturnCheckZSNES
     STA $2100   ; brightness + screen enable register
 	
 STP ; !
-
-warnpc $A19000
-
 ;--------------------------------------------------------------------------------
-org $378000
 
-; the ZSNES binary data will cross over to the $38xxxx bank ...
+; the ZSNES binary data below will cross over to the $38xxxx bank...
 ; ... but we expect this and handle it above by splitting the dma into two
-; the following check should be active when using asar - the ";@" prefix can be dropped when xkas support is dropped
+; hence, turning off the bankcross check/warning is safe.
+; the ";@" prefix can be dropped when xkas support is dropped
+
+;@ pushpc
 ;@ check bankcross off
+
+org $378000
 
 ZSNES_Tiles:
     incbin zsnes_tiles.bin
@@ -118,3 +117,4 @@ ZSNES_Palette:
     incbin zsnes_pal.bin
 	
 ;@ check bankcross on
+;@ pullpc

--- a/zsnes.asm
+++ b/zsnes.asm
@@ -103,9 +103,10 @@ warnpc $A19000
 ;--------------------------------------------------------------------------------
 org $378000
 
-; the ZSNES binary data will cross over to the $38xxxx bank - but we expect this
-; and handle it above.
-check bankcross off
+; the ZSNES binary data will cross over to the $38xxxx bank ...
+; ... but we expect this and handle it above by splitting the dma into two
+; the following check should be active when using asar - the ";@" prefix can be dropped when xkas support is dropped
+;@ check bankcross off
 
 ZSNES_Tiles:
     incbin zsnes_tiles.bin
@@ -116,4 +117,4 @@ ZSNES_TileMap:
 ZSNES_Palette:
     incbin zsnes_pal.bin
 	
-check bankcross on
+;@ check bankcross on

--- a/zsnes.asm
+++ b/zsnes.asm
@@ -1,4 +1,6 @@
 ;--------------------------------------------------------------------------------
+org $A18800 ; static mapping area
+
 CheckZSNES:
     SEP #$28
     LDA #$FF
@@ -95,8 +97,15 @@ JML.l ReturnCheckZSNES
     STA $2100   ; brightness + screen enable register
 	
 STP ; !
+
+warnpc $A19000
+
 ;--------------------------------------------------------------------------------
 org $378000
+
+; the ZSNES binary data will cross over to the $38xxxx bank - but we expect this
+; and handle it above.
+check bankcross off
 
 ZSNES_Tiles:
     incbin zsnes_tiles.bin
@@ -107,3 +116,4 @@ ZSNES_TileMap:
 ZSNES_Palette:
     incbin zsnes_pal.bin
 	
+check bankcross on


### PR DESCRIPTION
I've been doing some work on Asar recently, and wanted to test the z3randomizer source against it. During the testing, several compiler errors were found, as well as other issues with the generated assembly that caused behavioural differences in the generated ROM (e.g. crashing when entering any room/cave from the overworld, or crashes during the attract mode).

This PR includes fixes for all of those issues, allowing the code to not only be assembled against Asar, but also generate - with one exception - the exact same binary result as xkas was generating. 

The only lingering differences are:

- There are two references to bank of the binary data included in zsnes.asm, which are considered to be at bank B8 instead of bank 38, but this has no functional difference due to those banks shadowing one another
- The checksum in the header being different due to the above change

Edit: It should also be noted that this change does not affect the output when the patch is assembled with xkas. The changes either clarifies implicit behaviour that is different between xkas and Asar (the clarifications deferring to the xkas behaviour), or fixes areas where Asar is more strict about syntax in a backwards compatible fashion in areas xkas was more lenient.