### PR TITLE
Fix for less than 3 hearts at start

### DIFF
--- a/bugfixes.asm
+++ b/bugfixes.asm
@@ -148,3 +148,10 @@ WallmasterCameraFix:
 	STZ $061A  ; into thinking we're at the edge of the room so it doesn't scroll.
 	SEP #$20
 	JML Sound_SetSfx3PanLong ; what we wrote over, also this will RTL
+
+;--------------------------------------------------------------------------------
+; Fix spawning with more hearts than capacity when less than 3 heart containers
+LowHeartFix:
+	org $09F4AC ; <- module_death.asm:331
+	db $08, $08, $10
+;--------------------------------------------------------------------------------

--- a/bugfixes.asm
+++ b/bugfixes.asm
@@ -148,10 +148,3 @@ WallmasterCameraFix:
 	STZ $061A  ; into thinking we're at the edge of the room so it doesn't scroll.
 	SEP #$20
 	JML Sound_SetSfx3PanLong ; what we wrote over, also this will RTL
-
-;--------------------------------------------------------------------------------
-; Fix spawning with more hearts than capacity when less than 3 heart containers
-LowHeartFix:
-	org $09F4AC ; <- module_death.asm:331
-	db $08, $08, $10
-;--------------------------------------------------------------------------------


### PR DESCRIPTION
Fix to allow less than 3 hearts at start - respawn with capacity when less than 3, no change for above.