### PR TITLE
Changes to Ganon invulnerability

### DIFF
--- a/goalitem.asm
+++ b/goalitem.asm
@@ -75,15 +75,20 @@ GetRequriedCrystalsInX:
 	+ : DEC : TAX
 RTL
 ;--------------------------------------------------------------------------------
-CheckEnoughCrystals:
+CheckEnoughCrystalsForGanon:
 	LDA InvincibleGanon : CMP #$06 : BNE .normal
-	.other
 	PHX : PHY
 	LDA $7EF37A : JSL CountBits ; the comparison is against 1 less
 	PLY : PLX
-	CMP.l NumberOfCrystalsRequired
+	CMP.l NumberOfCrystalsRequiredForGanon
 RTL
-
 	.normal
 	LDA $7EF37A : AND.b #$7F : CMP.b #$7F ; thing we wrote over
+RTL
+;--------------------------------------------------------------------------------
+CheckEnoughCrystalsForTower:
+	PHX : PHY
+	LDA $7EF37A : JSL CountBits ; the comparison is against 1 less
+	PLY : PLX
+	CMP.l NumberOfCrystalsRequiredForTower
 RTL

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -12,7 +12,8 @@ GoalItemGanonCheck:
 		BCS .success
 		
 		.fail
-		LDA $0D80, X : CMP.b #17 : !BLT .success ; decmial 17 because Acmlm's chart is decimal
+		LDA $0D80, X : CMP.b #17 : !BLT .success ; decimal 17 because Acmlm's chart is decimal
+		LDA.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
 		LDA.b #$00
 RTL
 		.success

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -13,7 +13,7 @@ GoalItemGanonCheck:
 		
 		.fail
 		LDA $0D80, X : CMP.b #17 : !BLT .success ; decimal 17 because Acmlm's chart is decimal
-		LDA.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
+		LDA $0E60, X: AND.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
 		LDA.b #$00
 RTL
 		.success

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -13,7 +13,7 @@ GoalItemGanonCheck:
 		
 		.fail
 		LDA $0D80, X : CMP.b #17 : !BLT .success ; decimal 17 because Acmlm's chart is decimal
-		LDA $0E60, X: OR.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
+		LDA $0E60, X: ORA.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
 		LDA.b #$00
 RTL
 		.success

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -13,7 +13,7 @@ GoalItemGanonCheck:
 		
 		.fail
 		LDA $0D80, X : CMP.b #17 : !BLT .success ; decimal 17 because Acmlm's chart is decimal
-		LDA $0E60, X: AND.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
+		LDA $0E60, X: OR.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
 		LDA.b #$00
 RTL
 		.success

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -13,7 +13,7 @@ GoalItemGanonCheck:
 		
 		.fail
 		LDA $0D80, X : CMP.b #17 : !BLT .success ; decimal 17 because Acmlm's chart is decimal
-		LDA $0E60, X: ORA.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
+		LDA $0E60, X : ORA.b #$40 : STA $0E60, X ; make Ganon completely impervious to damage
 		LDA.b #$00
 RTL
 		.success


### PR DESCRIPTION
Make Ganon entirely impervious as opposed to just to the swords.
Allows for shenanigans such as modified damage tables to fight Ganon with bombs.
Won't affect vanilla gameplay, but makes life easier for damage table edits.