### PR TITLE
Prevent CountBottles from overwriting what is in register X. 

### DIFF
--- a/newitems.asm
+++ b/newitems.asm
@@ -1098,13 +1098,15 @@ AttemptItemSubstitution:
 RTS
 ;--------------------------------------------------------------------------------
 CountBottles:
-	LDX.b #$00
-	LDA $7EF35C : BEQ ++ : INX
-	++ : LDA $7EF35D : BEQ ++ : INX
-	++ : LDA $7EF35E : BEQ ++ : INX
-	++ : LDA $7EF35F : BEQ ++ : INX
-	++
-	TXA
+    PHX
+        LDX.b #$00
+        LDA $7EF35C : BEQ ++ : INX
+        ++ : LDA $7EF35D : BEQ ++ : INX
+        ++ : LDA $7EF35E : BEQ ++ : INX
+        ++ : LDA $7EF35F : BEQ ++ : INX
+        ++
+        TXA
+    PLX
 RTS
 ;--------------------------------------------------------------------------------
 ActivateGoal:


### PR DESCRIPTION
CountBottles sets X to the number of bottles.

(Shopkeeper.asm calls GetSpritePalette for example and needs X to not change after that call)