### PR TITLE
Triforce Hunt + Kill Ganon goal.

### DIFF
--- a/elder.asm
+++ b/elder.asm
@@ -41,6 +41,7 @@ RTL
     Elder_Code:
     {
         LDA GoalItemRequirement : BEQ .despawn
+        LDA InvincibleGanon : CMP #$05 : BEQ .despawn
         LDA TurnInGoalItems : BNE +
             .despawn
             STZ $0DD0, X ; despawn self

--- a/goalitem.asm
+++ b/goalitem.asm
@@ -43,8 +43,8 @@ CheckGanonVulnerability:
 		LDA $7EF2DB : AND.b #$20 : CMP #$20 : BNE .fail ; require aga2 defeated (pyramid hole open)
 		BRA .success
 	+ : CMP #$05 : BNE +
-		;#$05 = Require 100 Goal Items
-		LDA.l !GOAL_COUNTER : CMP.b #100 : !BLT .fail ; require 100 goal items
+		;#$05 = Require Goal Items
+		LDA.l !GOAL_COUNTER : CMP GoalItemRequirement : !BLT .fail ; require specified number of goal items
 		BRA .success
 	+ 
 .fail : CLC : RTL

--- a/tables.asm
+++ b/tables.asm
@@ -152,7 +152,7 @@ db #$00
 ; #$02 = Require All Dungeons
 ; #$03 = Require "NumberOfCrystalsRequiredForGanon" Crystals and Aga2
 ; #$04 = Require "NumberOfCrystalsRequiredForGanon" Crystals
-; #$05 = Require 100 Goal Items
+; #$05 = Require "GoalItemRequirement" Goal Items
 ;--------------------------------------------------------------------------------
 org $30803F ; PC 0x18003F
 HammerableGanon:


### PR DESCRIPTION
Allow configuring the rom to have a goal of Ganon locked by triforce pieces, instead of the usual goal of talking to the npc.

When Ganon is set to be triforce pieces (5), the elder will be despawned.  When he is set to be always invincible (1 / default triforce hunt setting) the current behaviour is preserved.