### PR TITLE
Fix fake world when fluting to pyramid twice

### DIFF
--- a/bugfixes.asm
+++ b/bugfixes.asm
@@ -82,6 +82,12 @@ RTS
 ; bunny on the pyramid
 FixAga2Bunny:
     LDA.l FixFakeWorld :  BEQ + ; Only use this fix is fakeworld fix is in use
+        LDA.l InvertedMode : BEQ +++
+            LDA.b #$00 : STA !DARK_WORLD ; Switch to light world
+            BRA ++
+        +++
+        LDA.b #$40 : STA !DARK_WORLD ; Switch to dark world
+    ++
 	JSL DecideIfBunny : BNE +
 		JSR MakeBunny
 		LDA.b #$04 : STA.w $012C ; play bunny music


### PR DESCRIPTION
When GT is in the light world, climbing GT twice puts you in fake dark world.
This was reported in door rando, when Aga2 was in a convenient spot to navigate to dark world.  It does happen in normal entrance rando as well, but players aren't likely to climb GT twice.