### PR TITLE
Low stakes and high stakes chest game no longer increments item counter.

### DIFF
--- a/hooks.asm
+++ b/hooks.asm
@@ -1270,6 +1270,10 @@ JSL.l RigDigRNG
 ;--------------------------------------------------------------------------------
 org $01EE94 ; <- EE94 - Bank01.asm : 14121
 JSL.l RigChestRNG
+org $01EEF5 ; <- EEF5 - Bank01.asm
+JSL.l FixChestCounterForChestGame
+org $01EEFD ; <- EEFD - Bank01.asm
+JSL.l FixChestCounterForChestGame
 ;--------------------------------------------------------------------------------
 org $1ED63E ; <- F563E - sprite_agahnim.asm
 JSL RNG_Agahnim1

--- a/rngfixes.asm
+++ b/rngfixes.asm
@@ -36,6 +36,11 @@ RTL
 	+
 RTL
 ;--------------------------------------------------------------------------------
+FixChestCounterForChestGame:
+	JSL.l DecrementItemCounter
+	JSL $0DBA71
+RTL
+;--------------------------------------------------------------------------------
 RNG_Lanmolas1:
 	LDA.b #$00 : BRA _rng_done
 RNG_Moldorm1:


### PR DESCRIPTION
Found this bug in through multiworld.  As it turns out, this bug has remained undetected for a long time.  Every single time you play one of the rupee chest games, the item counter goes up by one.  This patch fixes that.