### PR TITLE
Fix Lost Woods chest game respawn

### DIFF
--- a/darkworldspawn.asm
+++ b/darkworldspawn.asm
@@ -30,6 +30,7 @@ SetDeathWorldChecked:
 	LDA $1B : BEQ .outdoors
 		LDA $040C : CMP #$FF : BNE .dungeon
 		LDA $A0 : BNE ++
+		LDA $A1 : BNE ++
 			LDA GanonPyramidRespawn : BNE .pyramid ; if flag is set, force respawn at pyramid on death to ganon
 	    ++
 	.outdoors
@@ -67,6 +68,7 @@ SetDeathWorldChecked_Inverted:
 	LDA $1B : BEQ .outdoors
 		LDA $040C : CMP #$FF : BNE .dungeon
 		LDA $A0 : BNE ++
+		LDA $A1 : BNE ++
 			LDA GanonPyramidRespawn : BNE .castle ; if flag is set, force respawn at pyramid on death to ganon
 		++
 	.outdoors


### PR DESCRIPTION
Fixes the following issue:
To check if the player died in Ganon's room, only the low byte of $A0 is read. This means that if you die in the same room (0x00) on the EG2 map (Lost Woods chest game), you'll get sent straight to the pyramid/castle no matter if Aga 1 or 2 has been defeated.