### PR TITLE
Fix Agahnim Tower compass counter

### DIFF
--- a/compasses.asm
+++ b/compasses.asm
@@ -67,7 +67,7 @@ CompassCount_Desert:
 CompassCount_Agah:
 	%DrawConstantNumber(0,2)
 	SEP #$20
-	LDA $7EF435 : AND.b #$02
+	LDA $7EF435 : AND.b #$03
 	JMP DrawDungeonCompassCounts_return_spot
 
 CompassCount_Swamp:


### PR DESCRIPTION
Silly little off by one error, results in the "always on" dungeon counter NEVER displaying 01/02 when the first chest of Agahnim tower is collected, because that bit was NOT included in the AND statement.