### PR TITLE
Reset prize packs and other things on certain occasions

### DIFF
--- a/events.asm
+++ b/events.asm
@@ -80,6 +80,12 @@ OnAga2Defeated:
 	JSL.l IncrementAgahnim2Sword
 RTL
 ;--------------------------------------------------------------------------------
+OnFileCreation:
+	TAX ; what we wrote over
+	LDA StartingEquipment+$4C : STA $700340+$4C ; copy starting equipment swaps to file select screen
+	LDA StartingEquipment+$4E : STA $700340+$4E
+RTL
+;--------------------------------------------------------------------------------
 !RNG_ITEM_LOCK_IN = "$7F5090"
 OnFileLoad:
 	REP #$10 ; set 16 bit index registers
@@ -147,8 +153,6 @@ OnNewFile:
 		+
 
 		LDA StartingSword : STA $7EF359 ; set starting sword type
-		LDA !INVENTORY_SWAP : STA $70038C ; copy starting equipment swaps to file select screen
-		LDA !INVENTORY_SWAP_2 : STA $70038E
 
 		; reset some values on new file that are otherwise only reset on hard reset
 		STZ $03C4 ; ancilla slot index

--- a/events.asm
+++ b/events.asm
@@ -149,6 +149,16 @@ OnNewFile:
 		LDA StartingSword : STA $7EF359 ; set starting sword type
 		LDA !INVENTORY_SWAP : STA $70038C ; copy starting equipment swaps to file select screen
 		LDA !INVENTORY_SWAP_2 : STA $70038E
+
+		; reset some values on new file that are otherwise only reset on hard reset
+		STZ $03C4 ; ancilla slot index
+		STZ $047A ; EG
+		STZ $0B08 : STZ $0B09 ; arc variable
+		STZ $0CFB ; enemies killed (pull trees)
+		STZ $0CFC ; times taken damage (pull trees)
+		STZ $0FC7 : STZ $0FC8 : STZ $0FC9 : STZ $0FCA : STZ $0FCB : STZ $0FCC : STZ $0FCD ; prize packs
+		LDA #$00 : STA $7EC011 ; mosaic
+		JSL InitRNGPointerTable ; boss RNG
 	PLP : PLX
 RTL
 ;--------------------------------------------------------------------------------

--- a/hooks.asm
+++ b/hooks.asm
@@ -261,7 +261,9 @@ org $0CCE85 ; <- Bank0C.asm : 1953 (LDA $C8 : ASL A : INC #2 : STA $701FFE)
 NOP #4
 ;--------------------------------------------------------------------------------
 org $0CDB4C ; <- Bank0C.asm : 3655 (LDA $C8 : ASL A : INC #2 : STA $701FFE : TAX)
-NOP #4
+JSL OnFileCreation
+NOP
+;Additionally, display inventory swap starting equipment on file select
 ;--------------------------------------------------------------------------------
 org $09F5EA ; <- module_death.asm : 510 (LDA $701FFE : TAX : DEX #2)
 LDA.w #$0002 : NOP

--- a/init.asm
+++ b/init.asm
@@ -56,5 +56,6 @@ RTL
 Init_PostRAMClear:
 
 	JSL MSUInit
+	JSL InitRNGPointerTable
 
 JML $00D463	; The original target of the jump table that we hijacked

--- a/rngfixes.asm
+++ b/rngfixes.asm
@@ -107,9 +107,9 @@ RTL
 !RNG_POINTERS = "$7F5200"
 GetStaticRNG:
 	PHX : PHP
-	REP #$20 ; set 16-bit accumulator and index registers
-	AND.w #$007F
-	ASL : TAX : LDA !RNG_POINTERS, X : INC : AND.w #$03FF : STA !RNG_POINTERS, X : TAX : ASL ; increment pointer and move value to X
+	REP #$30 ; set 16-bit accumulator and index registers
+	AND.w #$000F
+	ASL : TAX : LDA !RNG_POINTERS, X : INC : AND.w #$03FF : STA !RNG_POINTERS, X : TAX ; increment pointer and move value to X
 	LDA Static_RNG, X ; load RNG value
 	PLP : PLX
 RTL
@@ -123,7 +123,7 @@ InitRNGPointerTable:
 		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
 		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
 		LDA.l .rngDefaults, X : STA !RNG_POINTERS, X : INX #2
-	CPX.w #$007F : !BLT -
+	CPX.w #$001F : !BLT -
 	PLP : PLX
 RTL
 .rngDefaults

--- a/save.asm
+++ b/save.asm
@@ -1,5 +1,13 @@
 ;--------------------------------------------------------------------------------
 Validate_SRAM:
+	REP #$30 ; vanilla behavior from $0CCD45, includes prize pack reset after save and quit
+		LDX #$00FE : -
+			STZ $0D00, X
+			STZ $0E00, X
+			STZ $0F00, X
+			DEX #2
+		BPL -
+	SEP #$30
 RTL
 ;--------------------------------------------------------------------------------
 ClearExtendedSaveFile:


### PR DESCRIPTION
This resets certain addresses after deleting and creating a new file that are normally only reset on a hard reset. This ensures that boss RNG, prize pack progression and some other things don't carry over from a deleted file. This is mostly for racing and speedrunning.
It also restores the vanilla behavior of resetting prize pack progression after a save and quit without having to hard reset.
When creating a new file, starting equipment from the inventory swap addresses is now properly displayed before loading the file for the first time.