### PR TITLE
Now possible to start with 0 bomb capacity

### DIFF
--- a/capacityupgrades.asm
+++ b/capacityupgrades.asm
@@ -6,7 +6,8 @@
 ;--------------------------------------------------------------------------------
 IncrementBombs:
     LDA !BOMB_UPGRADES ; get bomb upgrades
-	!ADD.l StartingMaxBombs : DEC
+	!ADD.l StartingMaxBombs : BEQ + ; Skip if we can't have bombs
+	DEC
 
     CMP !BOMB_CURRENT
 	

--- a/inventory.asm
+++ b/inventory.asm
@@ -738,6 +738,7 @@ RTS
 Link_ReceiveItem_HUDRefresh:
 	LDA $7EF343 : BNE + ; skip if we have bombs
 	LDA $7EF375 : BEQ + ; skip if we are filling no bombs
+	LDA $7EF370 : !ADD.l StartingMaxBombs : BEQ + ; skip if we can't have bombs
 		DEC : STA $7EF375 ; decrease bomb fill count
 		LDA.b #$01 : STA $7EF343 ; increase actual bomb count
 	+
@@ -753,6 +754,7 @@ RTL
 HandleBombAbsorbtion:
 	STA $7EF375 ; thing we wrote over
 	LDA $0303 : BNE + ; skip if we already have some item selected
+	LDA $7EF370 : !ADD.l StartingMaxBombs : BEQ + ; skip if we can't have bombs
 		LDA.b #$04 : STA $0202 ; set selected item to bombs
 		LDA.b #$01 : STA $0303 ; set selected item to bombs
 		JSL.l HUD_RebuildLong


### PR DESCRIPTION
These three minor changes are all that is required for one to be able to start the game with 0 bomb capacity (by changing StartingMaxBombs in the rando-settings). Previously if you set this to 0 it caused an underflow that gave you 255 bomb capacity.

This also includes a fix to the way "auto-equip bombs when no item is equipped" work so that it does not happen when your bomb capacity is 0.
