### PR TITLE
Quickswap bottle y pressed

### DIFF
--- a/inventory.asm
+++ b/inventory.asm
@@ -124,7 +124,9 @@ RTL
 ;ProcessBottleMenu:
 ;--------------------------------------------------------------------------------
 ProcessBottleMenu:
+	LDA $F6 : AND #$30 : CMP.b #$30 : BEQ .double_shoulder_pressed
 	LDA $F4 : AND #$40 : BEQ .y_not_pressed ; skip if Y is not down
+	.double_shoulder_pressed
 	LDA $7EF34F ; check bottle state
 	BEQ .no_bottles ; skip if we have no bottles
 	PHX

--- a/inventory.asm
+++ b/inventory.asm
@@ -124,9 +124,9 @@ RTL
 ;ProcessBottleMenu:
 ;--------------------------------------------------------------------------------
 ProcessBottleMenu:
-	LDA $F6 : AND #$30 : CMP.b #$30 : BEQ .double_shoulder_pressed
-	LDA $F4 : AND #$40 : BEQ .y_not_pressed ; skip if Y is not down
-	.double_shoulder_pressed
+;	LDA $F6 : AND #$30 : CMP.b #$30 : BEQ .double_shoulder_pressed
+;	LDA $F4 : AND #$40 : BEQ .y_not_pressed ; skip if Y is not down
+;	.double_shoulder_pressed
 	LDA $7EF34F ; check bottle state
 	BEQ .no_bottles ; skip if we have no bottles
 	PHX
@@ -139,9 +139,9 @@ ProcessBottleMenu:
 	.no_bottles
 	LDA #$00 ; pretend like the controller state was 0 from the overridden load
 RTL
-	.y_not_pressed
-	LDA $F4 : AND.b #$0C ; thing we wrote over - load controller state
-RTL
+;	.y_not_pressed
+;	LDA $F4 : AND.b #$0C ; thing we wrote over - load controller state
+;RTL
 ;--------------------------------------------------------------------------------
 
 ;--------------------------------------------------------------------------------

--- a/quickswap.asm
+++ b/quickswap.asm
@@ -38,6 +38,7 @@ QuickSwap:
 	CPX.b #$01 : BEQ + ; bow
 	CPX.b #$05 : BEQ + ; powder
 	CPX.b #$0D : BEQ + ; flute
+	CPX.b #$10 : BEQ + ; bottle
 	BRA .store
 	+ STX $0202 : JSL ProcessMenuButtons_y_pressed
 
@@ -54,20 +55,20 @@ RTL
 RCode:
 	LDA.w $0202 : TAX
 	-
-		CPX.b #$0F : BNE + ; incrementing into bottle
-			LDX.b #$00 : BRA ++
-		+ CPX.b #$10 : BNE + ; incrementing bottle
-			LDA.l $7EF34F : TAX
-			-- : ++
-				CPX.b #$04 : BEQ .noMoreBottles
-				INX
-				LDA.l $7EF35B,X : BEQ --
-			TXA : STA.l $7EF34F
-			LDX #$10
-			RTS
-			.noMoreBottles
-			LDX #$11
-			BRA .nextItem
+;		CPX.b #$0F : BNE + ; incrementing into bottle
+;			LDX.b #$00 : BRA ++
+;		+ CPX.b #$10 : BNE + ; incrementing bottle
+;			LDA.l $7EF34F : TAX
+;			-- : ++
+;				CPX.b #$04 : BEQ .noMoreBottles
+;				INX
+;				LDA.l $7EF35B,X : BEQ --
+;			TXA : STA.l $7EF34F
+;			LDX #$10
+;			RTS
+;			.noMoreBottles
+;			LDX #$11
+;			BRA .nextItem
 		+ CPX.b #$14 : BNE + : LDX.b #$00 ;will wrap around to 1
 		+ INX
 	.nextItem
@@ -77,19 +78,19 @@ RTS
 LCode:
 	LDA.w $0202 : TAX
 	-
-		CPX.b #$11 : BNE + ; decrementing into bottle
-			LDX.b #$05 : BRA ++
-		+ CPX.b #$10 : BNE +	; decrementing bottle
-			LDA.l $7EF34F : TAX
-			-- : ++
-				CPX.b #$01 : BEQ .noMoreBottles
-				DEX
-				LDA.l $7EF35B,X : BEQ --
-			TXA : STA.l $7EF34F
-			LDX.b #$10
-			RTS
-			.noMoreBottles
-			LDX.b #$0F : BRA .nextItem
+;		CPX.b #$11 : BNE + ; decrementing into bottle
+;			LDX.b #$05 : BRA ++
+;		+ CPX.b #$10 : BNE +	; decrementing bottle
+;			LDA.l $7EF34F : TAX
+;			-- : ++
+;				CPX.b #$01 : BEQ .noMoreBottles
+;				DEX
+;				LDA.l $7EF35B,X : BEQ --
+;			TXA : STA.l $7EF34F
+;			LDX.b #$10
+;			RTS
+;			.noMoreBottles
+;			LDX.b #$0F : BRA .nextItem
 		+ CPX.b #$01 : BNE + : LDX.b #$15 ; will wrap around to $14
 		+ DEX
 	.nextItem


### PR DESCRIPTION
This is the simple version of not cycling through bottles with quickswap. It replaces the functionality of cycling through all the bottles with double-shoulder "Y presses".

I had originally added a check in ProcessBottleMenu to bypass the Y check, but it turns out that check doesn't seem to be necessary because the calling subroutine is already checking if Y is pressed so instead both items are commented out. This made the double-shoulder press for bottle as smooth as the one for shovel/flute.



It would also be possible to do a more complex version where the flag variable ( 0x30804B ) could be either:
* 0x00 == off
* 0x01 == old behavior
* 0x02 == new behavior

That would take front-end work that i'm not necessarily willing to do.