### PR TITLE
Revert "Update entrances.asm"

### DIFF
--- a/entrances.asm
+++ b/entrances.asm
@@ -4,7 +4,9 @@
 ;--------------------------------------------------------------------------------
 LockAgahnimDoors:
 	LDA.l AgahnimDoorStyle : AND.w #$00FF
-	BEQ .exit ; don't need to load 0, because we'd have it if we reached here
+	BNE +
+		;#$0 = Never Locked
+		LDA.w #$0000 : RTL
 	+ : CMP.w #$0001 : BNE +
 		LDA $7EF3C5 : AND.w #$000F : CMP.w #$0002 : !BGE .unlock ; if we rescued zelda, skip
 			JSR.w LockAgahnimDoorsCore : RTL
@@ -35,7 +37,7 @@ LockAgahnimDoors:
 	.unlock
 
 	LDA.w #$0000 ; fallback to never locked
-.exit
+
 RTL
 ;--------------------------------------------------------------------------------
 LockAgahnimDoorsCore:
@@ -202,14 +204,14 @@ RTL
 AnimatedEntranceFix: ;when an entrance animation tries to start
 	PHA
 	LDA.l InvertedMode : BEQ + ;If we are in inverted mode
-	PLA
-	BIT $8A : BVS ++ ; and in the light world
+	LDA $8A : AND.b #$40 : BNE + ;and in the light world
+		PLA
 		STZ $04C6 ; skip it.
 		LDA #$00
 		RTL
 	+
 	PLA
-++	STA $02E4 ;what we wrote over
+	STA $02E4 ;what we wrote over
 	STA $0FC1 ;what we wrote over
 	STA $0710 ;what we wrote over
 RTL


### PR DESCRIPTION
This reverts commit f4a336d and fixes a bug in inverted mode where the animations for opening PoD and Misery Mire would not begin properly, hard locking the game. Also reverts some refactored Aga Tower door code.