### PR TITLE
Rewrite electro palette flashing

### DIFF
--- a/accessibility.asm
+++ b/accessibility.asm
@@ -162,7 +162,7 @@ RestoreBgEther:
             INX #2 : CPX.b #$10 : BNE -
             BRA ++
         ++
-JML $02FF51
+JML $02FF51 ; Bank0E.asm : 3936 vanilla restore routine after loop which RTLs
 ;================================================================================
 DDMConditionalLightning:
         LDA.l DisableFlashing 
@@ -170,7 +170,7 @@ DDMConditionalLightning:
         BNE +
             LDA.w $0000
             LDX.b #$02
-            JML $07FA7F
+            JML $07FA7F ; Bank0E.asm : 4738 vanilla loop equivalent to below beginning at LDY #$00
         +
             LDA.b $00 : LDX.b #$02 : LDY #$00
         -
@@ -181,13 +181,11 @@ DDMConditionalLightning:
             LDA $F523, Y : LDA $7EC5F0, X
             INY #2
             INX #2 : CPX.b #$10 : BNE -
-JML $07FAAC
+            JML $07FAAC ; Bank0E.asm : 4754 both branches converge here
 ;================================================================================
 ConditionalGTFlash:
-        LDA.l DisableFlashing
-            REP #$20
-            BNE +
-                LDA $0000
+        LDA.l DisableFlashing : REP #$20 : BNE +
+            LDA $0000
         -
             LDA $F9C1, Y : STA $7EC5D0, X
             INY #2
@@ -199,11 +197,10 @@ ConditionalGTFlash:
             LDA $F9C1, Y : LDA $7EC5D0, X
             INY #2
             INX #2 : CPX.b #$10 : BNE -
-RTL
+            RTL
 ;================================================================================
 ConditionalRedFlash:
-        LDA.l DisableFlashing
-        REP #$20 : BNE +
+        LDA.l DisableFlashing : REP #$20 : BNE +
             LDA $00,X
             LDA.w #$1D59 : STA $7EC5DA
             LDA.w #$25FF : STA $7EC5DC
@@ -240,14 +237,12 @@ LoadElectroPalette:
         SEP #$10
         LDX $0D
         LDA $1BEBC1, X : AND.w #$00FF : ADC #$D648
-        REP #$10
-        LDX.w #$01B8 : LDY.w #$0003
+        REP #$10 : LDX.w #$01B8 : LDY.w #$0003
         JSR ConditionalLoadGearPalette
         SEP #$10
         LDX $0E
         LDA $1BEC06, X : AND.w #$00FF : ASL A : ADC #$D308
-        REP #$10
-        LDX.w #$01E2 : LDY.w #$000E
+        REP #$10 : LDX.w #$01E2 : LDY.w #$000E
         JSR ConditionalLoadGearPalette
         SEP #$30
         INC $15
@@ -275,7 +270,7 @@ ConditionalLoadGearPalette:
                 INX #2
                 DEY
                 BPL -
-RTS
+        RTS
 ;================================================================================
 RestoreElectroPalette:
         REP #$30

--- a/accessibility.asm
+++ b/accessibility.asm
@@ -24,8 +24,7 @@ RTL
 ;================================================================================
 ConditionalWhitenBg:
         LDX.b #$00
-        LDA.l DisableFlashing
-        REP #$20 : BNE +
+        LDA.l DisableFlashing : REP #$20 : BNE +
             LDA $00,X
             JSR WhitenLoopReal
             RTL
@@ -55,10 +54,10 @@ WhitenLoopReal:
             LDA $7EC3F4 : JSL Filter_Majorly_Whiten_Color : STA $7EC5F4
             LDA $10 : CMP.w #$07 : BNE +
             LDA $048E
-            CMP.w #$3C : BEQ ++ ; hookshot cave
-            CMP.w #$9D : BEQ ++ ; gt right
-            CMP.w #$9C : BEQ ++ ; gt big room
-            CMP.w #$A5 : BEQ ++ ; wizzrobes 1
+            CMP.w #$3C : BEQ ++
+            CMP.w #$9D : BEQ ++
+            CMP.w #$9C : BEQ ++
+            CMP.w #$A5 : BEQ ++
             +
                 LDA $7EC3F6 : JSL Filter_Majorly_Whiten_Color : STA $7EC5F6
                 LDA $7EC3F8 : JSL Filter_Majorly_Whiten_Color : STA $7EC5F8
@@ -68,7 +67,6 @@ WhitenLoopReal:
                 LDA $7EC3F8 : JSL Filter_Majorly_Whiten_Color : STA $7EC5F8
                 BRA +++
             +++
-
             LDA $7EC3FA : JSL Filter_Majorly_Whiten_Color : STA $7EC5FA
             LDA $7EC3FC : JSL Filter_Majorly_Whiten_Color : STA $7EC5FC
             LDA $7EC3FE : JSL Filter_Majorly_Whiten_Color : STA $7EC5FE
@@ -97,7 +95,6 @@ WhitenLoopDummy:
             INX #2 : CPX.b #$10 : BEQ +
                 JMP -
         +
-
             LDA $7EC3F0 : JSL Filter_Majorly_Whiten_Color : LDA $7EC5F0
             LDA $7EC3F2 : JSL Filter_Majorly_Whiten_Color : LDA $7EC5F2
             LDA $7EC3F4 : JSL Filter_Majorly_Whiten_Color : LDA $7EC5F4
@@ -165,7 +162,7 @@ RestoreBgEther:
             INX #2 : CPX.b #$10 : BNE -
             BRA ++
         ++
-            JML $02FF51 
+JML $02FF51
 ;================================================================================
 DDMConditionalLightning:
         LDA.l DisableFlashing 
@@ -184,7 +181,6 @@ DDMConditionalLightning:
             LDA $F523, Y : LDA $7EC5F0, X
             INY #2
             INX #2 : CPX.b #$10 : BNE -
-
 JML $07FAAC
 ;================================================================================
 ConditionalGTFlash:
@@ -213,17 +209,15 @@ ConditionalRedFlash:
             LDA.w #$25FF : STA $7EC5DC
             LDA.w #$001A
             RTL
-
         +
             LDA $00
             LDA.w #$1D59 : LDA $7EC5DA
             LDA.w #$25FF : LDA $7EC5DC
             LDA.w #$0000
-RTL
+            RTL
 ;================================================================================
 ConditionalPedAncilla:
-        LDA.l DisableFlashing
-        REP #$20 : BNE +
+        LDA.l DisableFlashing : REP #$20 : BNE +
             LDA $00,X
             LDA $00 : STA $04
             LDA $02 : STA $06
@@ -232,32 +226,74 @@ ConditionalPedAncilla:
             LDA $00
             LDA $00 : LDA $04
             LDA $02 : LDA $06
+            RTL
+;================================================================================
+LoadElectroPalette:
+        REP #$20
+        LDA.w #$0202 : STA $0C
+        LDA.w #$0404 : STA $0E
+        LDA.w #$001B : STA $02
+        SEP #$10
+        LDX $0C : LDA $1BEBB4, X : AND.w #$00FF : ADC #$D630
+        REP #$10 : LDX.w #$01B2 : LDY.w #$0002
+        JSR ConditionalLoadGearPalette
+        SEP #$10
+        LDX $0D
+        LDA $1BEBC1, X : AND.w #$00FF : ADC #$D648
+        REP #$10
+        LDX.w #$01B8 : LDY.w #$0003
+        JSR ConditionalLoadGearPalette
+        SEP #$10
+        LDX $0E
+        LDA $1BEC06, X : AND.w #$00FF : ASL A : ADC #$D308
+        REP #$10
+        LDX.w #$01E2 : LDY.w #$000E
+        JSR ConditionalLoadGearPalette
+        SEP #$30
+        INC $15
 RTL
 ;================================================================================
-ConditionalChangeGearPalette:
-    PHY
-    STA $00
-    SEP #$20
-    LDA.l DisableFlashing : REP #$20 : BNE +
-    LDA $00,X
-    -
-        LDA [$00] : STA $7EC300, X : STA $7EC500, X
-        INC $00 : INC $00
-        INX #2
-        DEY : BPL -
-        BRA ++
-    +
-    LDA $00
-    -
-        LDA [$00] : LDA $7EC300, X : LDA $7EC500, X
-        INC $00 : INC $00
-        INX #2
-        DEY : BPL -
-        BRA ++
-    ++
-    PLY ; use what was in Y register to determine which p flags to set
-    CPY #$000E : BNE + 
+ConditionalLoadGearPalette:
+        STA $00
         SEP #$20
-    +
-        SEP #$10
+        LDA.l DisableFlashing : REP #$20 : BNE +
+                LDA $00,X
+        -
+                LDA [$00]
+                STA $7EC500, X
+                INC $00 : INC $00
+                INX #2
+                DEY
+                BPL -
+        RTS
+        +
+                LDA $00
+        -
+                LDA [$00]
+                LDA $7EC500, X
+                INC $00 : INC $00
+                INX #2
+                DEY
+                BPL -
+RTS
+;================================================================================
+RestoreElectroPalette:
+        REP #$30
+        LDX.w #$01B2 : LDY.w #$0002
+        JSR FillPaletteBufferFromAux
+        LDX.w #$01B8 : LDY.w #$0003
+        JSR FillPaletteBufferFromAux
+        LDX.w #$01E2 : LDY.w #$000E
+        JSR FillPaletteBufferFromAux
+        SEP #$30
+        INC $15
 RTL
+;================================================================================
+FillPaletteBufferFromAux:
+        -
+            LDA $7EC300, X
+            STA $7EC500, X
+            INX #2
+            DEY
+            BPL -
+RTS

--- a/events.asm
+++ b/events.asm
@@ -16,7 +16,7 @@ OnPrepFileSelect:
 OnDrawHud:
 	JSL.l DrawChallengeTimer ; this has to come before NewDrawHud because the timer overwrites the compass counter
 	JSL.l NewDrawHud
-	JSL.l SwapSpriteIfNecissary
+	JSL.l SwapSpriteIfNecessary
 	JSL.l CuccoStorm
 	JSL.l PollService
 JML.l ReturnFromOnDrawHud

--- a/hooks.asm
+++ b/hooks.asm
@@ -737,9 +737,6 @@ dw $0000, $0002, $0004, $0032, $0004, $0006, $0030
 ;JSL FlipGreenPendant
 ;NOP #6
 ;--------------------------------------------------------------------------------
-org $08AAF9 ; -< 42AF9 - ancilla_ether_spell.asm : 46 (JSL Palette_Restore_BG_From_Flash)
-JSL.l RestoreBgEther
-;--------------------------------------------------------------------------------
 org $02A3F4 ; <- 123F4 - Bank02.asm : 6222 (LDA.b #$72 : BRA .setBrightness)
 BRA + : NOP #2 : +
 org $02A3FD ; <- 123FD - Bank02.asm : 6233 (LDA.b #$32 : STA $9a)
@@ -747,6 +744,15 @@ JSL.l ConditionalLightning
 ;--------------------------------------------------------------------------------
 org $1DE9CD ; <- EE9CD - Bank1D.asm : 568 (JSL Filter_Majorly_Whiten_Bg)
 JSL.l ConditionalWhitenBg
+;--------------------------------------------------------------------------------
+org $08AAE9 ; <- 042AE9 - ancilla_ether_spell.asm : 34 (JSL Palette_ElectroThemedGear)
+JSL.l LoadElectroPalette
+;--------------------------------------------------------------------------------
+org $08AAF5 ; <- 042AF5 - ancilla_ether_spell.asm : 45 (JSL LoadActualGearPalettes)
+JSL.l RestoreElectroPalette
+;--------------------------------------------------------------------------------
+org $08AAF9 ; -< 42AF9 - ancilla_ether_spell.asm : 46 (JSL Palette_Restore_BG_From_Flash)
+JSL.l RestoreBgEther
 ;--------------------------------------------------------------------------------
 org $08AAED ; <- 42AED - ancilla_ether_spell.asm : 35 (JSL Filter_Majorly_Whiten_Bg)
 JSL.l ConditionalWhitenBg
@@ -766,14 +772,13 @@ JSL.l ConditionalRedFlash : BRA + : NOP #13 : +
 org $08C2A1 ; <- 442A3 - ancilla_sword_ceremony.asm : 54 (REP #$20)
 JSL.l ConditionalPedAncilla : BRA + : NOP #4 : +
 ;--------------------------------------------------------------------------------
-org $02FDB1 ; <- 17DB1 - Bank0E.asm : 3760 (JSL LoadGearPalette)
-JSL.l ConditionalChangeGearPalette : NOP
+org $079976 ; <- 039976 - Bank07.asm : 4009 (JSL Palette_ElectroThemedGear)
+JSL.l LoadElectroPalette
 ;--------------------------------------------------------------------------------
-org $02FDCB ; <- 17DCB - Bank0E.asm : 3775 (JSL LoadGearPalette)
-JSL.l ConditionalChangeGearPalette : NOP
+org $07997C ; <- 03997C - Bank07.asm : 4015 (JSL LoadActualGearPalettes) 
+JSL.l RestoreElectroPalette
 ;--------------------------------------------------------------------------------
-org $02FDE6 ; <- 17DE6 - Bank0E.asm : 3789 (JSL LoadGearPalette)
-JSL.l ConditionalChangeGearPalette : NOP
+
 ;================================================================================
 ; Ice Floor Toggle
 ;--------------------------------------------------------------------------------

--- a/spriteswap.asm
+++ b/spriteswap.asm
@@ -15,7 +15,7 @@ RTL
 !BANK_BASE = "#$29"
 
 org $BF8000
-SwapSpriteIfNecissary:
+SwapSpriteIfNecessary:
 	PHP
 		SEP #$20 ; set 8-bit accumulator
 		LDA !SPRITE_SWAP : BEQ + : !ADD !BANK_BASE : CMP $BC : BEQ +


### PR DESCRIPTION
All non-electro instances of gear palette changing (eg bunny palette) are now untouched by the flashing code. This writes palette changes to the buffer at `7EC500` (or computes them and then LDAs instead of STA-ing if flashing disabled) when Link is electrocuted or in the Ether animation. To restore the palette, it simply copies from the auxiliary buffer at `7EC300` in all cases regardless of the state of the flashing flag. 

Have tested some possible edge cases including super bunny being electrocuted by a bari in Skull Woods and using Ether in the Thieves Town hellway. As far as I can tell the behavior is consistent when flashing is enabled compared to the randomizer rom before the new accessibility code. This also maintains randomizer behavior where glove colors remain consistent with the set of gloves that the player has and are not overwritten.