### PR TITLE
Utilities: Fix progressive bow sprite replacement

### DIFF
--- a/utilities.asm
+++ b/utilities.asm
@@ -89,8 +89,12 @@ RTL
 		+ ; Everything Else
 			LDA.b #$2E : RTL
 	++ : CMP.b #$F8 : BNE ++ ; Progressive Bow
-		LDA $7EF340
-		CMP.b #$00 : BNE + ; No Bow
+		LDA $7EF340 : INC : LSR
+		CMP.l ProgressiveBowLimit : !BLT +
+			LDA.l ProgressiveBowReplacement
+			JSL.l GetSpriteID
+			RTL
+		+ : CMP.b #$00 : BNE + ; No Bow
 			LDA.b #$29 : RTL
 		+ ; Any Bow
 			LDA.b #$2A : RTL
@@ -225,7 +229,12 @@ RTL
 		+ ; Everything Else
 			LDA.b #$08 : RTL
 	++ : CMP.b #$F8 : BNE ++ ; Progressive Bow
-		LDA $7EF354 : BNE + ; No Bow
+		LDA $7EF340 : INC : LSR
+		CMP.l ProgressiveBowLimit : !BLT +
+			LDA.l ProgressiveBowReplacement
+			JSL.l GetSpritePalette
+			RTL
+		+ : CMP.b #$00 : BNE + ; No Bow
 			LDA.b #$08 : RTL
 		+ ; Any Bow
 			LDA.b #$02 : RTL


### PR DESCRIPTION
Progressive bow sprites replacements either did not account for the max limit or were flat out broken in the palette's case

This applies to same logic as ``AddReceivedItemExpanded`` in https://github.com/KatDevsGames/z3randomizer/blob/d0fbd11d0f6c5b2a45ee20deb0a87a925592c93a/newitems.asm#L501-L506