### PR TITLE
Events: Fix unusable infinite bombs with empty inventory

### DIFF
--- a/events.asm
+++ b/events.asm
@@ -55,12 +55,15 @@ OnQuit:
 RTL
 ;--------------------------------------------------------------------------------
 OnUncleItemGet:
-	JSL Link_ReceiveItem
+	PHA
 
 	LDA.l EscapeAssist
 	BIT.b #$04 : BEQ + : STA !INFINITE_MAGIC : +
 	BIT.b #$02 : BEQ + : STA !INFINITE_BOMBS : +
 	BIT.b #$01 : BEQ + : STA !INFINITE_ARROWS : +
+
+	PLA
+	JSL Link_ReceiveItem
 
 	LDA.l UncleRefill : BIT.b #$04 : BEQ + : LDA.b #$80 : STA $7EF373 : + ; refill magic
 	LDA.l UncleRefill : BIT.b #$02 : BEQ + : LDA.b #50 : STA $7EF375 : + ; refill bombs

--- a/hooks.asm
+++ b/hooks.asm
@@ -319,6 +319,15 @@ JSL.l LoadBombCount16
 org $0DDEB3 ; <- 6DEB3 - equipment.asm : 328 (LDA $7EF33F, X)
 JSL.l IsItemAvailable
 ;--------------------------------------------------------------------------------
+org $0DDDE8 ; <- 6DDE8 - equipment.asm : 148 (LDA $7EF340)
+JSL.l SearchForEquippedItem
+;--------------------------------------------------------------------------------
+org $0DDE70 ; <- 6DE70 - equipment.asm : 273 (LDA $7EF340)
+JSL.l SearchForEquippedItem
+;--------------------------------------------------------------------------------
+org $0DE39D ; <- 6E39D - equipment.asm : 1109 (LDA $7EF340)
+JSL.l SearchForEquippedItem
+;--------------------------------------------------------------------------------
 
 ;================================================================================
 ; Inverted Mode

--- a/retro.asm
+++ b/retro.asm
@@ -26,6 +26,12 @@ StoreBombCount:
 	.finite
 		PLA : STA $7EF343
 RTL
+SearchForEquippedItem:
+	LDA !INFINITE_BOMBS : BEQ +
+		LDA.b #$01 : LDX.b #$00 : RTL
+	+
+	LDA $7EF340 ; thing we wrote over
+RTL
 
 !INFINITE_ARROWS = "$7F50C8"
 DecrementArrows:


### PR DESCRIPTION
Infinite bombs would not be selectable in the menu if you didnt have another item available, which can happen when uncle gives you a sword
The selected item also would be refreshed (in ``Link_ReceiveItem``) before we enable the bombs so you'd have to menu from an empty slot to equip them