### PR TITLE
Stats: Fix bonk counter

### DIFF
--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -570,6 +570,9 @@ AddDashTremor:
 org $099D04
 AddAncillaLong:
 
+org $099D1A
+Ancilla_CheckIfAlreadyExistsLong:
+
 org $09AE64
 Sprite_SetSpawnedCoords:
 

--- a/stats.asm
+++ b/stats.asm
@@ -142,17 +142,14 @@
 !LOCK_STATS = "$7EF443"
 ;--------------------------------------------------------------------------------
 !BONK_COUNTER = "$7EF420"
-!BONK_REPEAT = "$7F503F"
-!LOOP_FRAMES_LOW = "$7EF42E"
 StatBonkCounter:
 	PHA
+	JSL Ancilla_CheckIfAlreadyExistsLong : BCS +
 		LDA !LOCK_STATS : BNE +
-		LDA !LOOP_FRAMES_LOW : !SUB !BONK_REPEAT : CMP #30 : !BLT +
-			LDA !LOOP_FRAMES_LOW : STA !BONK_REPEAT
 			LDA !BONK_COUNTER : INC
 			CMP.b #100 : BEQ + ; decimal 100
 				STA !BONK_COUNTER
-		+
+	+
 	PLA
 	JSL.l AddDashTremor ; thing we wrote over
 RTL

--- a/tables.asm
+++ b/tables.asm
@@ -1471,7 +1471,7 @@ dw #9999 ; Rupee Limit
 ; $7F503C - Stats Rupee Total
 ; $7F503D - Stats Rupee Total
 ; $7F503E - Stats Item Total
-; $7F503F - Bonk Repeat
+; $7F503F - Unused
 ; $7F5040 - Free Item Dialog Temporary
 ; $7F5041 - Epilepsy Safety Timer
 ; $7F5042 - Tile Upload Offset Override (Low)


### PR DESCRIPTION
Previously we would check our bonk timer against ``LOOP_FRAMES_LOW `` which obviously overflows all the time, effectively giving you a 30/256 chance of not counting the bonk. Instead let's check if a bonk ancilla already exists since we're going to create it with ``AddDashTremor``