### PR TITLE
Minor Low-Priority Fixes

### DIFF
--- a/stats/creditsnew.asm
+++ b/stats/creditsnew.asm
@@ -1,11 +1,13 @@
 ;===================================================================================================
 ; LEAVE THIS HERE FOR PHP WRITES
 ;===================================================================================================
+table "creditscharmapbighi.txt"
 YourSpriteCreditsHi:
 db 2
 db 55
 db "                            " ; $238002
 
+table "creditscharmapbiglo.txt"
 YourSpriteCreditsLo:
 db 2
 db 55

--- a/stats/main.asm
+++ b/stats/main.asm
@@ -218,7 +218,7 @@ endmacro
 
 !ColonOffset = $83
 !PeriodOffset = $80
-!BlankTile = $883D
+!BlankTile = #$883D
 
 RenderCreditsStatCounter:
     PHB

--- a/tables.asm
+++ b/tables.asm
@@ -837,7 +837,7 @@ db #$08 ; #$08 = 1 Heart (default) - #$02 = 1/4 Heart
 ;================================================================================
 org $308169 ; PC 0x180169
 AgahnimDoorStyle:
-db #$02 ; #00 = Never Locked - #$01 = Locked During Escape (default) - #$02 = Locked Without 7 Crystals
+db #$01 ; #00 = Never Locked - #$01 = Locked During Escape (default) - #$02 = Locked Without 7 Crystals
 ;================================================================================
 org $30816A ; PC 0x18016A
 FreeItemText:


### PR DESCRIPTION
- Changes default for locked aga tower from 2 (locked until all 7 crystals obtained, correct for inverted) to 1 (locked until after escape, correct for open/standard)
- Correctly set table before literal for sprite author name, so the default is blank instead of lots of tiny Gs
- Changes references to !BlankTile to be as an immediate value (blank) instead of an address value (that happens to be blank for the moment)

Randomizers explicitly set the first two values, so they're not a huge impact beyond testing; the third is brittle but only an issue for the moment if code gets shifted around in the credits/stats section. It could be a nasty surprise for someone trying to change something in the credits though.