### PR TITLE
Fix drawing C/P indicator

### DIFF
--- a/newhud.asm
+++ b/newhud.asm
@@ -145,9 +145,10 @@ SEP #$30
 	SEP #$20
 	LDA.b $1B : BEQ .noprize
 
-
-
-	LDX.w $040C : BMI .noprize
+	LDX.w $040C
+	CPX #$1A : !BGE .noprize
+	CPX #$04 : !BLT .noprize
+	CPX #$08 : BEQ .noprize
 
 	REP #$20
 
@@ -156,9 +157,10 @@ SEP #$30
 
 	LDA.l $7EF368
 	AND.l DungeonItemMasks,X
-	BEQ .doneprize
+	BEQ .noprize
 
 .drawprize
+	TXA : LSR : TAX
 	LDA.l CrystalPendantFlags_2, X
 	AND.w #$0040 : BNE .is_crystal
 

--- a/newhud.asm
+++ b/newhud.asm
@@ -150,6 +150,8 @@ SEP #$30
 	CPX #$04 : !BLT .noprize
 	CPX #$08 : BEQ .noprize
 
+	LDA $10 : CMP #$12 : BEQ .noprize
+
 	REP #$20
 
 	LDA.l MapMode

--- a/stats/creditsnew.asm
+++ b/stats/creditsnew.asm
@@ -419,7 +419,7 @@ CreditsLineBlank:
 
 %blankline()
 
-%bigcredits("AERINON             COMPILING")
+%bigcredits("AERINON            COMPILING")
 
 %blankline()
 %blankline()


### PR DESCRIPTION
Fix three small bugs:
- wrong indicator would sometimes be displayed, due to using dungeon index which is based around even values to look up values in a table that only has one byte per dungeon
- aga tower, hyrule castle, sewers, and GT would all show P
- in map shuffle, dungeons the player does not have the map for would draw some junk data