### PR TITLE
rngfixes: make enemy drop rng static during the standard escape sequence

### DIFF
--- a/hooks.asm
+++ b/hooks.asm
@@ -1491,6 +1491,9 @@ org $1DBAB1 ; <- EBAB1 - sprite_sidenexx.asm : 314 (JSL GetRandomInt : AND.b #$0
 JSL.l RNG_Trinexx
 org $1DBAC3 ; <- EBAC3 - sprite_sidenexx.asm : 323 (JSL GetRandomInt : AND.b #$0F : ADD.b #$0C : STA $02 : STZ $03)
 JSL.l RNG_Trinexx
+;--------------------------------------------------------------------------------
+org $6F9B8 ; <- 379B8 - bank06.asm : 6693 (JSL GetRandomInt : PLY  : AND $FA5C, Y : BNE BRANCH_MU)
+JSL.l RNG_Enemy_Drops
 ;================================================================================
 ; HUD Changes
 ;--------------------------------------------------------------------------------

--- a/rngfixes.asm
+++ b/rngfixes.asm
@@ -4,8 +4,7 @@
 RigDigRNG:
 	LDA $7FFE01 : CMP.l DiggingGameRNG : !BGE .forceHeart
 	.normalItem
-	JSL $0DBA71 ; GetRandomInt
-RTL
+	JML GetRandomInt
 	.forceHeart
 	LDA $7FFE00 : BNE .normalItem
 	LDA #$04
@@ -15,7 +14,7 @@ RigChestRNG:
 	JSL.l DecrementChestCounter
 	LDA $04C4 : CMP.l ChestGameRNG : BEQ .forceHeart
 	.normalItem
-	JSL $0DBA71 ; GetRandomInt
+	JSL GetRandomInt
 	AND.b #$07 ; restrict values to 0-7
 	CMP #$07 : BEQ .notHeart
 	JSL.l DecrementItemCounter
@@ -29,7 +28,7 @@ RTL
 	JSL.l DecrementItemCounter
 	;LDA #$00 ; bullshit rupee farming in chest game
 	
-	JSL $0DBA71 ; GetRandomInt ; spam RNG until we stop getting the prize item
+	JSL GetRandomInt ; spam RNG until we stop getting the prize item
 	AND.b #$07 ; restrict values to 0-7
 	CMP #$07 : BNE + ; player got prize item AGAIN
 		LDA.b #$00 ; give them money instead
@@ -97,6 +96,11 @@ RNG_Ganon_Extra_Warp:
 	+
 	PLA
 	RTL
+RNG_Enemy_Drops:
+        LDA.l $7EF3C5 : CMP #$01 : BEQ + ; drops are static after uncle pickup & before rescuing zelda
+            JML GetRandomInt
+        +
+            LDA.b #$0F
 	_rng_done:
 	JSL.l GetStaticRNG
 RTL
@@ -142,5 +146,5 @@ dw #$02C0 ; 11 = Agahnim 2
 dw #$0300 ; 12 = Agahnim 2 Phantoms
 dw #$0340 ; 13 = Ganon
 dw #$0380 ; 14 = Ganon Extra Warp
-dw #$03C0 ; 15 = Unused
+dw #$03C0 ; 15 = Standard Escape Enemy Drops
 ;--------------------------------------------------------------------------------


### PR DESCRIPTION
This only applies between picking up the Uncle item and dropping off zelda, not rain state in general. Checks whether the "progress indicator" in SRAM is 0x01 (indicating a game state between picking up the uncle item and bringing Zelda to the sanctuary.) If it is, it uses the static RNG to determine whether the player gets a drop or not. If the game is in any post-escape or pre-uncle state, it jumps to the vanilla RNG routine.

I've also updated a few long jumps to GetRandomInt which were labeled by address with the text label and replaced one instance of `JSL GetRandomInt : RTL` with `JML GetRandomInt` since that routine returns long anyway.