### PR TITLE
Fix clearing frog/smith in inverted mode

### DIFF
--- a/darkworldspawn.asm
+++ b/darkworldspawn.asm
@@ -53,8 +53,9 @@ DoWorldFix_Inverted:
 	.aga1Alive
 	LDA #$40 : STA $7EF3CA ; set flag to dark world
 	LDA $7EF3CC
-	CMP #$07 : BNE .done ; clear frog
-	CMP #$08 : BNE .done ; clear dwarf - consider flute implications
+	CMP #$07 : BEQ .clear ; clear frog
+	CMP #$08 : BEQ .clear ; clear dwarf - consider flute implications
+	BRA .done
 	.clear
 	LDA.b #$00 : STA $7EF3CC ; clear follower
 	.done


### PR DESCRIPTION
Fixes an issue in inverted mode where you can softlock if you grab the smith early - the current version incorrectly checks for follower id equal to both 7 and 8, instead of one of those values.