### PR TITLE
Fix OHKO mode

### DIFF
--- a/events.asm
+++ b/events.asm
@@ -176,6 +176,7 @@ OnInitFileSelect:
 RTL
 ;--------------------------------------------------------------------------------
 OnLinkDamaged:
+	JSL.l IncrementDamageTakenCounter_Arb
 	JSL.l FlipperKill
 	JML.l OHKOTimer
 

--- a/hooks.asm
+++ b/hooks.asm
@@ -2705,8 +2705,6 @@ JSL FastTextScroll : NOP
 org $01FFEE : JSL IncrementDamageTakenCounter_Eight ; overworld pit
 org $079506 : JSL IncrementDamageTakenCounter_Eight ; underworld pit
 
-org $0780C6 : JSL IncrementDamageTakenCounter_Arb
-
 org $07B0B1 : JSL IncrementMagicUseCounter
 
 ;================================================================================


### PR DESCRIPTION
The hook for incrementing the damage counter when Link takes damage overwrote a different hook, which ultimately removed the check for OHKO mode to immediately kill Link.