### PR TITLE
Fix check for wild maps

### DIFF
--- a/newhud.asm
+++ b/newhud.asm
@@ -152,9 +152,8 @@ SEP #$30
 
 	LDA $10 : CMP #$12 : BEQ .noprize
 
-	REP #$20
-
 	LDA.l MapMode
+	REP #$20
 	BEQ .drawprize
 
 	LDA.l $7EF368


### PR DESCRIPTION
Read the MapMode byte in 8-bit mode so that having some form of dungeon item counters (wild compasses or Door Shuffle) doesn't mess with this check.