### PR TITLE
Add ROM version to unused hw vector and before filename in SRAM

### DIFF
--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -28,8 +28,8 @@ org $1FFFF8 ; <- FFFF8 timestamp rom
 db #$20, #$19, #$08, #$31 ; year/month/day
 
 ;================================================================================
-!ROM_VERSION_LOW = 1  ; ROM version (two 16-bit integers)
-!ROM_VERSION_HIGH = 1 ;
+!ROM_VERSION_LOW ?= 1  ; ROM version (two 16-bit integers)
+!ROM_VERSION_HIGH ?= 1 ;
 
 org $00FFE0 ; Unused hardware vector
 RomVersion:

--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -28,6 +28,15 @@ org $1FFFF8 ; <- FFFF8 timestamp rom
 db #$20, #$19, #$08, #$31 ; year/month/day
 
 ;================================================================================
+!ROM_VERSION_LOW = 1  ; ROM version (two 16-bit integers)
+!ROM_VERSION_HIGH = 1 ;
+
+org $00FFE0 ; Unused hardware vector
+RomVersion:
+dw !ROM_VERSION_LOW
+dw !ROM_VERSION_HIGH
+
+;================================================================================
 
 !ADD = "CLC : ADC"
 !SUB = "SEC : SBC"

--- a/init.asm
+++ b/init.asm
@@ -1,3 +1,5 @@
+RomVersionSRAM = $701FFC
+
 ;--------------------------------------------------------------------------------
 ; Init_Primary
 ;--------------------------------------------------------------------------------
@@ -39,6 +41,11 @@ Init_Primary:
 			LDA $00FFC0, X : STA $702000, X
 			INX
 			CPX #$15 : !BLT -
+                LDX #$00
+                -
+                        LDA RomVersion, X : STA RomVersionSRAM, X
+                        INX
+                        CPX #$04 : !BLT -
 	.done
 
 	REP #$20


### PR DESCRIPTION
Two 16 bit ints located at $FFE0 (0x7FE0 PC) in ROM and burned into SRAM
starting at $701FFC, just before the ROM name