### PR TITLE
Dungeons completed reverse

### DIFF
--- a/LTTP_RND_GeneralBugfixes.asm
+++ b/LTTP_RND_GeneralBugfixes.asm
@@ -433,6 +433,8 @@ org $00891D
 org $00893D
 EnableForceBlank:
 
+DungeonMask = $0098C0
+
 org $00D308
 DecompSwordGfx:
 

--- a/inventory.asm
+++ b/inventory.asm
@@ -682,8 +682,10 @@ RTS
 
 .setDungeonCompletion
 	LDX $040C : BMI +
+		REP #$20  ; 16 bit
 		LDA.l DungeonMask, X
 		ORA DungeonsCompleted : STA DungeonsCompleted
+		SEP #$20  ; 8 bit
 	+
 RTS
 ;--------------------------------------------------------------------------------

--- a/inventory.asm
+++ b/inventory.asm
@@ -681,30 +681,10 @@ RTL
 RTS
 
 .setDungeonCompletion
-        LDA $040C
-	CMP #$FF : BEQ +
-		LSR : AND #$0F : CMP #$08 : !BGE ++
-			JSR .valueShift
-			ORA DungeonsCompleted : STA DungeonsCompleted
-			BRA +
-		++
-			!SUB #$08
-			JSR .valueShift
-			BIT.b #$C0 : BEQ +++ : LDA.b #$C0 : +++ ; Make Hyrule Castle / Sewers Count for Both
-			ORA DungeonsCompleted+1 : STA DungeonsCompleted+1
+	LDX $040C : BMI +
+		LDA.l DungeonMask, X
+		ORA DungeonsCompleted : STA DungeonsCompleted
 	+
-RTS
-
-.valueShift
-	PHX
-	TAX : LDA.b #$01
-	-
-		CPX #$00 : BEQ +
-		ASL
-		DEX
-	BRA -
-	+
-	PLX
 RTS
 ;--------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR reverses the storage of the bits in the DungeonsCompleted bitfield to match the order in CompassField, BigKeyField, and MapField (all 3 of those are vanilla)