### PR TITLE
Check submodule during goal NPC interaction to prevent it from firing when menu is open

### DIFF
--- a/elder.asm
+++ b/elder.asm
@@ -50,6 +50,8 @@ RTL
             RTS
         +
         SEP #$20
+        LDA.b $11
+        BNE .done
         LDA.b #$96
         LDY.b #$01
         


### PR DESCRIPTION
(via kan)