### PR TITLE
darkworldspawn: Add check for old man to fix post-aga spawn bug

### DIFF
--- a/darkworldspawn.asm
+++ b/darkworldspawn.asm
@@ -11,10 +11,11 @@ DoWorldFix:
 		JMP DoWorldFix_Inverted
 	+
 	LDA.l Bugfix_MirrorlessSQToLW : BEQ .skip_mirror_check
+                LDA.l FollowerIndicator : CMP #$04 : BEQ .setLightWorld ; check if old man is following
 		LDA MirrorEquipment : BEQ .noMirror ; check if we have the mirror
 	.skip_mirror_check ; alt entrance point
 	LDA ProgressIndicator : CMP.b #$03 : BCS .done ; check if agahnim 1 is alive
-	.aga1Alive
+        .setLightWorld
 	LDA #$00
 	.noMirror
 	STA CurrentWorld ; set flag to light world
@@ -46,11 +47,11 @@ RTL
 ;================================================================================
 DoWorldFix_Inverted:
 	LDA.l Bugfix_MirrorlessSQToLW : BEQ .skip_mirror_check
-		LDA MirrorEquipment : BEQ .noMirror ; check if we have the mirror
+                LDA.l FollowerIndicator : CMP #$04 : BEQ .setDarkWorld ; check if old man is following
+		LDA MirrorEquipment : BEQ .setDarkWorld ; check if we have the mirror
 	.skip_mirror_check ; alt entrance point
 	LDA ProgressIndicator : CMP.b #$03 : BCS .done ; check if agahnim 1 is alive
-	.noMirror
-	.aga1Alive
+        .setDarkWorld
 	LDA #$40 : STA CurrentWorld ; set flag to dark world
 	LDA FollowerIndicator
 	CMP #$07 : BEQ .clear ; clear frog


### PR DESCRIPTION
This fixes a bug where the player would spawn at the post-aga starting entrance if they died or saved and quit in the "opposite" world of the old man (dark world or light world in inverted) with Agahnim 1 dead and the mirror collected. If the `Bugfix_MirrorlessSQToLW` flag is set (set to $01, or the randomizer behavior, by default in every popular frontend including door rando,) then the player will always spawn in the old man cave when the old man is following them.

If the flag is not set, then the player will always spawn at the post-aga starting entrance with Agahnim 1 defeated regardless of whether they have the mirror or the old man is following them and will retain the old man follower in all cases which is the vanilla game behavior.