### PR TITLE
Glitch fixes

### DIFF
--- a/events.asm
+++ b/events.asm
@@ -29,6 +29,7 @@ OnDungeonBossExit:
         JSL.l StatTransitionCounter
         LDX.w DungeonID : BMI +
                 LDA.w RoomIndex : CMP.b #$0D : BEQ .aga2
+                LDA.w RoomIndex : CMP.b #$20 : BEQ .aga
                         .set_completed
                         REP #$20
                         LDA.l DungeonItemMasks, X : ORA.l DungeonsCompleted : STA.l DungeonsCompleted
@@ -37,6 +38,9 @@ OnDungeonBossExit:
 RTL
         .aga2
         CPX.b #$1A : BEQ .set_completed
+RTL
+        .aga
+        CPX.b #$08 : BEQ .set_completed
 RTL
 ;--------------------------------------------------------------------------------
 OnPlayerDead:

--- a/heartpieces.asm
+++ b/heartpieces.asm
@@ -211,7 +211,10 @@ LoadIndoorValue:
 		LDA.l StandingKey_Hera
 		JMP .done
 	+
-	LDA.w #$0017 ; default to a normal hp
+        PHX
+        LDX.w CurrentSpriteSlot ; If we're on a different screen ID via glitches load the sprite
+        LDA.w SpriteID,X        ; we can see and are interacting with
+        PLX
 	.done
 	AND.w #$00FF ; the loads are words but the values are 1-byte so we need to clear the top half of the accumulator - no guarantee it was 8-bit before
 	PLP
@@ -274,7 +277,10 @@ LoadOutdoorValue:
 		%GetPossiblyEncryptedItem(HeartPiece_Zora, HeartPieceOutdoorValues)
 		JMP .done
 	+
-	LDA.w #$0017 ; default to a normal hp
+        PHX
+        LDX.w CurrentSpriteSlot ; If we're on a different screen ID via glitches load the sprite
+        LDA.w SpriteID,X        ; we can see and are interacting with.
+        PLX
 	.done
 	AND.w #$00FF ; the loads are words but the values are 1-byte so we need to clear the top half of the accumulator - no guarantee it was 8-bit before
 	PLP

--- a/stats/credits.asm
+++ b/stats/credits.asm
@@ -443,10 +443,10 @@ CreditsLineBlank:
 
 %blankline()
 
-%bigcredits("MATRETHEWEY           IBAZLY")
+%bigcredits("         MATRETHEWEY        ")
 
 %blankline()
-%bigcredits("FISH_WAFFLE64        KRELBEL")
+%bigcredits("FISH_WAFFLE64         IBAZLY")
 
 %blankline()
 


### PR DESCRIPTION
-Fix overworld item duping
-Fix setting dungeon completed when Aga 1 is defeated. The bitfield used affects whether prizes drop so we don't want a dungeon's set if Aga 1 is killed instead of a prize boss.