### PR TITLE
Names for Patreon Supporters

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -2,4 +2,4 @@
 
 rm ../working.sfc
 cp ../alttp.sfc ../working.sfc
-./bin/linux/asar LTTP_RND_GeneralBugfixes.asm ../working.sfc
+./bin/linux/asar -DFEATURE_PATREON_SUPPORTERS=1 LTTP_RND_GeneralBugfixes.asm ../working.sfc

--- a/stats/credits.asm
+++ b/stats/credits.asm
@@ -19,37 +19,37 @@ table "data/creditscharmapbighi.txt"
 PatronCredit1Hi:
 db 2
 db 55
-db "                            " ; $238002
+db "                            " ; $23803E
 
 table "data/creditscharmapbiglo.txt"
 PatronCredit1Lo:
 db 2
 db 55
-db "                            " ; $238020
+db "                            " ; $23805C
 
 table "data/creditscharmapbighi.txt"
 PatronCredit2Hi:
 db 2
 db 55
-db "                            " ; $238038
+db "                            " ; $23807A
 
 table "data/creditscharmapbiglo.txt"
 PatronCredit2Lo:
 db 2
 db 55
-db "                            " ; $238056
+db "                            " ; $238098
 
 table "data/creditscharmapbighi.txt"
 PatronCredit3Hi:
 db 2
 db 55
-db "                            " ; $238074
+db "                            " ; $2380B6
 
 table "data/creditscharmapbiglo.txt"
 PatronCredit3Lo:
 db 2
 db 55
-db "                            " ; $238092
+db "                            " ; $2380D4
 
 ;===================================================================================================
 

--- a/stats/credits.asm
+++ b/stats/credits.asm
@@ -13,6 +13,44 @@ db 2
 db 55
 db "                            " ; $238020
 
+!FEATURE_PATREON_SUPPORTERS ?= 0
+
+table "data/creditscharmapbighi.txt"
+PatronCredit1Hi:
+db 2
+db 55
+db "                            " ; $238002
+
+table "data/creditscharmapbiglo.txt"
+PatronCredit1Lo:
+db 2
+db 55
+db "                            " ; $238020
+
+table "data/creditscharmapbighi.txt"
+PatronCredit2Hi:
+db 2
+db 55
+db "                            " ; $238038
+
+table "data/creditscharmapbiglo.txt"
+PatronCredit2Lo:
+db 2
+db 55
+db "                            " ; $238056
+
+table "data/creditscharmapbighi.txt"
+PatronCredit3Hi:
+db 2
+db 55
+db "                            " ; $238074
+
+table "data/creditscharmapbiglo.txt"
+PatronCredit3Lo:
+db 2
+db 55
+db "                            " ; $238092
+
 ;===================================================================================================
 
 CreditsLineTable:
@@ -498,6 +536,23 @@ CreditsLineBlank:
 %blankline()
 %blankline()
 
+if !FEATURE_PATREON_SUPPORTERS
+	%smallcredits("PATREON SUPPORTERS", "yellow")
+
+	%addarbline(PatronCredit1Hi)
+	%addarbline(PatronCredit1Lo)
+
+	%blankline()
+	%addarbline(PatronCredit2Hi)
+	%addarbline(PatronCredit2Lo)
+
+	%blankline()
+	%addarbline(PatronCredit3Hi)
+	%addarbline(PatronCredit3Lo)
+
+	%blankline()
+endif
+
 %smallcredits("SPECIAL THANKS", "red")
 
 %blankline()
@@ -530,7 +585,7 @@ CreditsLineBlank:
 
 %blankline()
 
-%bigcredits("AND&")
+%bigcredits("AND")
 
 %blankline()
 
@@ -556,16 +611,19 @@ CreditsLineBlank:
 %emptyline()
 %emptyline()
 %emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
-%emptyline()
+
+if !FEATURE_PATREON_SUPPORTERS == 0
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+	%emptyline()
+endif
 
 ;===================================================================================================
 

--- a/stats/credits.asm
+++ b/stats/credits.asm
@@ -551,6 +551,7 @@ if !FEATURE_PATREON_SUPPORTERS
 	%addarbline(PatronCredit3Lo)
 
 	%blankline()
+	%blankline()
 endif
 
 %smallcredits("SPECIAL THANKS", "red")
@@ -610,9 +611,9 @@ endif
 %emptyline()
 %emptyline()
 %emptyline()
-%emptyline()
 
 if !FEATURE_PATREON_SUPPORTERS == 0
+	%emptyline()
 	%emptyline()
 	%emptyline()
 	%emptyline()


### PR DESCRIPTION
Adds extra dynamic text in the credits for patron recognition.  This is setup as a define so local builds of the ROM won't include the section (though the ROM space is still reserved).