### PR TITLE
Fix dungeon prize ancilla spawn regression

### DIFF
--- a/dungeondrops.asm
+++ b/dungeondrops.asm
@@ -3,6 +3,9 @@
 ;--------------------------------------------------------------------------------
 SpawnDungeonPrize:
         PHX : PHB
+        TAX
+        LDA.b $06,S : STA.b ScrapBuffer72 ; Store current RoomTag index
+        TXA
         JSL.l AttemptItemSubstitution
         JSL.l ResolveLootIDLong
         STA.w ItemReceiptID
@@ -14,6 +17,7 @@ SpawnDungeonPrize:
                 LDA.w ItemReceiptID
                 STA.w AncillaGet,X : STA.w SpriteID,X
                 JSR.w AddDungeonPrizeAncilla
+                LDX.b ScrapBuffer72 : STZ.b RoomTag,X
         .failed_spawn
         PLB : PLX
 RTL

--- a/hooks.asm
+++ b/hooks.asm
@@ -1000,7 +1000,7 @@ org $81C517 : JSL.l CheckDungeonCompletion
 org $81C523 : JSL.l CheckDungeonCompletion
 org $81C710 : JSL.l CheckSpawnPrize
 BCS RoomTag_GetHeartForPrize_spawn_prize : BRA RoomTag_GetHeartForPrize_delete_tag
-org $81C742 : JSL.l SpawnDungeonPrize
+org $81C742 : JSL.l SpawnDungeonPrize : PLA : RTS
 org $8799EA : JML.l SetItemPose
 org $88C415 : JSL.l PendantMusicCheck
 BCS Ancilla22_ItemReceipt_is_pendant : BRA Ancilla22_ItemReceipt_wait_for_music


### PR DESCRIPTION
Restores behavior that continues to attempt spawning the dungeon prize until success when too many sprites are initially on screen (e.g. with somaria projectiles.)