### PR TITLE
Update HUD when picking up bonk key

### DIFF
--- a/bookofmudora.asm
+++ b/bookofmudora.asm
@@ -65,6 +65,7 @@ GiveBonkItem:
 		PHY : LDY.b #$24 : JSL.l AddInventory : PLY ; do inventory processing for a small key
 		LDA.l CurrentSmallKeys : INC A : STA.l CurrentSmallKeys
 		LDA.b #$2F : JSL.l Sound_SetSfx3PanLong
+                INC.w UpdateHUDFlag
 RTL
 	.notKey
 		PHY : TAY : JSL.l Link_ReceiveItem : PLY

--- a/heartpieces.asm
+++ b/heartpieces.asm
@@ -45,9 +45,11 @@ DrawHeartPieceGFX:
                         LDA.w SpriteControl, X : ORA.b #$20 : STA.w SpriteControl, X
                         PLA
                         JSL.l DrawDynamicTile
+                        REP #$21
                         LDA.b Scrap00
-                        CLC : ADC.b #$04
+                        ADC.w #$0004
                         STA.b Scrap00
+                        SEP #$20
                         JSL.l Sprite_DrawShadowLong
                         BRA .done
                 +


### PR DESCRIPTION
Setting this flag will properly update HUD elements like the total item counter when a torch key is absorbed.