### PR TITLE
Bomb count fix

### DIFF
--- a/retro.asm
+++ b/retro.asm
@@ -11,8 +11,9 @@ LoadBombCount16:
 	.infinite
 RTL
 StoreBombCount:
+	PHA
 	LDA.b #$01 : STA.l UpdateHUDFlag
-	PHA : LDA.l InfiniteBombs : BEQ .finite
+	LDA.l InfiniteBombs : BEQ .finite
 	.infinite
 		PLA : LDA.b #$01 : RTL
 	.finite


### PR DESCRIPTION
PHA placed incorrectly results in bomb count being reset to 01 after each placement. 