### PR TITLE
Fix credits spacing

### DIFF
--- a/stats/credits.asm
+++ b/stats/credits.asm
@@ -503,6 +503,8 @@ CreditsLineBlank:
 
 %smallcredits("YOUR SPRITE BY", "yellow")
 
+%blankline()
+
 %addarbline(YourSpriteCreditsHi)
 %addarbline(YourSpriteCreditsLo)
 
@@ -538,6 +540,8 @@ CreditsLineBlank:
 
 if !FEATURE_PATREON_SUPPORTERS
 	%smallcredits("PATREON SUPPORTERS", "yellow")
+
+	%blankline()
 
 	%addarbline(PatronCredit1Hi)
 	%addarbline(PatronCredit1Lo)
@@ -609,10 +613,9 @@ endif
 %emptyline()
 %emptyline()
 %emptyline()
-%emptyline()
-%emptyline()
 
 if !FEATURE_PATREON_SUPPORTERS == 0
+	%emptyline()
 	%emptyline()
 	%emptyline()
 	%emptyline()


### PR DESCRIPTION
I don't know if this bothers anyone other than me, but there is no blank line between `YOUR SPRITE BY` and the sprite author, or between `PATREON SUPPORTERS` and the three patreon supporters, while there is a blank line after all the other headings before the corresponding people are listed.

This PR fixes this.

Before:
![credits_000](https://github.com/user-attachments/assets/f21a95de-ad4d-45fd-afb8-78a99a4123d7) ![credits_001](https://github.com/user-attachments/assets/321aec53-6a91-4f32-a94d-337b67fb0bf4)

After:
![credits_002](https://github.com/user-attachments/assets/09b9b2b1-71d2-4771-bd47-95425ba46249) ![credits_003](https://github.com/user-attachments/assets/586e622a-9549-4801-bbec-104b0c2be20a)
