### PR TITLE
v32: Allow moldorm to have more than two eyes

### DIFF
--- a/enemy_adjustments.asm
+++ b/enemy_adjustments.asm
@@ -25,3 +25,17 @@ NewFireBarDamage:
                 RTL
 .NotSameLayer
 RTL
+
+;--------------------------------------------------------------------------------
+; Moldorm_UpdateOamPosition:
+; adjust oam space to the maximum of 8 possible eyes
+;--------------------------------------------------------------------------------
+Moldorm_UpdateOamPosition:
+	REP #$21
+	LDA.b $90
+	ADC.w #$0020
+	STA.b $90
+	LDA.b $92
+	ADC.w #$08
+	STA.b $92
+RTL

--- a/hooks.asm
+++ b/hooks.asm
@@ -2588,5 +2588,10 @@ org $00E213 : JSL GetSpriteSheet2
 org $00E222 : JSL GetSpriteSheet3
 org $00E231 : JSL GetSpriteSheet4
 
-
+;================================================================================
+; Moldorm eye drawing for more than two eyes
+;--------------------------------------------------------------------------------
+org $1DD88C ; <- bank_1D.asm
+JSL Moldorm_UpdateOamPosition
+JMP.w $1DD89A
 


### PR DESCRIPTION
Noticed this while trying to add moldorm eye randomization support to v32, nothing beyond 2 eyes worked.

I don't claim to have understood _everything_, but I _think_ the problem is not having enough OAM space to hold more than just two eyes. Those patches are mostly from kan, but he only threw ASM at me; so I hope that's good enough locations for it. Because Moldorm is always alone in the room, it _should_ be fine to just allocate enough space for 8 eyes regardless of the actual count.