### PR TITLE
No logic fixes

### DIFF
--- a/dungeondrops.asm
+++ b/dungeondrops.asm
@@ -3,6 +3,16 @@
 ;--------------------------------------------------------------------------------
 SpawnDungeonPrize:
         PHX : PHB
+
+        PHA
+        ; Don't spawn prize in Cave state, Hyrule Castle, Escape, Castle Tower, or Ganon's Tower
+        LDA.w DungeonID : BMI .skip_prize_drop ; Cave state
+        CMP.b #$00 : BEQ .skip_prize_drop ; Escape
+        CMP.b #$02 : BEQ .skip_prize_drop ; Hyrule Castle
+        CMP.b #$1A : BEQ .skip_prize_drop ; Ganon's Tower
+        CMP.b #$08 : BEQ .skip_prize_drop ; Agahnim's Tower (Castle Tower)
+        PLA
+
         TAX
         LDA.b $06,S : STA.b ScrapBuffer72 ; Store current RoomTag index
         TXA
@@ -20,6 +30,10 @@ SpawnDungeonPrize:
                 LDX.b ScrapBuffer72 : STZ.b RoomTag,X
         .failed_spawn
         PLB : PLX
+RTL
+
+.skip_prize_drop:
+        PLA : PLB : PLX
 RTL
 
 AddDungeonPrizeAncilla:

--- a/heartpieces.asm
+++ b/heartpieces.asm
@@ -234,6 +234,12 @@ LoadOutdoorValue:
 	PHP
 	REP #$20 ; set 16-bit accumulator
 	LDA.b OverworldIndex
+	; Rain state fix: In rain state DW, use LW screen ID for item lookup
+	BIT.w #$0040 : BEQ +
+		LDA.l ProgressIndicator : AND.w #$00FF : CMP.w #$0002
+			LDA.b OverworldIndex : BCS ++ : AND.w #$00BF
+		++
+	+
 	CMP.w #$03 : BNE +
 		LDA.b LinkPosX : CMP.w #1890 : !BLT ++
 			%GetPossiblyEncryptedItem(HeartPiece_Spectacle, HeartPieceOutdoorValues)

--- a/tablets.asm
+++ b/tablets.asm
@@ -19,8 +19,14 @@ RTL
 ;--------------------------------------------------------------------------------
 SetTabletItemFlag:     
         PHA
-                LDA.b OverworldIndex : CMP.b #$03 : BEQ .ether ; if we're on the map where ether is, we're the ether tablet
-                .bombos
+                ; Rain state fix: convert DW screen ID to LW if in rain state
+                LDA.b OverworldIndex
+				BIT.b #$40 : BEQ + 
+						LDA.l ProgressIndicator : CMP.b #$02
+						LDA.b OverworldIndex : BCS ++ : AND.b #$BF
+					++
+				+
+                CMP.b #$03 : BEQ .ether ; if we're on the map where ether is, we're the ether tablet                .bombos
                 JSR ItemSet_BombosTablet : BRA .done
                 .ether
                 JSR ItemSet_EtherTablet
@@ -70,6 +76,12 @@ RTL
 IsMedallion:
 	REP #$20 ; set 16-bit accumulator
 	LDA.b OverworldIndex
+	; Rain state fix: In rain state DW, use LW screen ID for tablet lookup
+	BIT.w #$0040 : BEQ + 
+			LDA.l ProgressIndicator : AND.w #$00FF : CMP.w #$0002
+			LDA.b OverworldIndex : BCS ++ : AND.w #$00BF
+		++
+	+
 	CMP.w #$03 : BNE + ; Death Mountain
 		LDA.b LinkPosX : CMP.w #1890 : !BGE ++
 			SEC


### PR DESCRIPTION
There are 2 fixes here:
1) Prevents prizes dropping in Cave state, as well as HC, CT and GT. 
2) Fixes rain state items. Currently they end up as itemID 0 as they read the DW sprite list and become sword & shield items. This shifts them back to the previous behaviour of becoming the LW items..